### PR TITLE
Add an HTTPS agent for localhost request

### DIFF
--- a/packages/app/main/src/fetchProxy.spec.ts
+++ b/packages/app/main/src/fetchProxy.spec.ts
@@ -61,7 +61,17 @@ describe('fetch proxy support', () => {
   it('should not add the http-proxy-agent when the HTTPS_PROXY is omitted', () => {
     delete process.env.HTTPS_PROXY;
     delete process.env.NO_PROXY;
-    fetch('https://localhost').catch();
+    fetch('https://some.api.com').catch();
+    expect(mockFetchArgs.init).toBeUndefined();
+  });
+
+  it('should add the https-agent to localhost requests', async () => {
+    await fetch('https://localhost:3980');
+    expect(mockFetchArgs.init.agent).not.toBeUndefined();
+  });
+
+  it('should not add https-agent to the https requests', async () => {
+    await fetch('http://localhost:3980');
     expect(mockFetchArgs.init).toBeUndefined();
   });
 });

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -44,6 +44,7 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   const https = require('https');
   const httpsAgent = new https.Agent({ rejectUnauthorized: false });
   const allowLocalhost = 'https://localhost';
+
   if (args[0].includes(allowLocalhost)) {
     requestInit.agent = httpsAgent;
   }

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -40,6 +40,7 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   const [urlOrRequest, requestInit = {}] = args;
 
   // Https localhost
+  // eslint-disable-next-line typescript/no-var-requires
   const https = require('https');
   const httpsAgent = new https.Agent({ rejectUnauthorized: false });
   if (args[0].includes('https://localhost')) {

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -38,6 +38,14 @@ const nodeFetch = require('node-fetch');
 declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 (global as any).fetch = function(...args: any[]) {
   const [urlOrRequest, requestInit = {}] = args;
+
+  // Https localhost
+  const https = require('https');
+  const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+  if (args[0].includes('https://localhost')) {
+    requestInit.agent = httpsAgent;
+  }
+
   // No Proxy
   const url: string = typeof urlOrRequest === 'string' ? urlOrRequest : urlOrRequest.url;
   if (!process.env.HTTPS_PROXY || (process.env.NO_PROXY && url.includes(process.env.NO_PROXY))) {

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -43,7 +43,8 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   // eslint-disable-next-line typescript/no-var-requires
   const https = require('https');
   const httpsAgent = new https.Agent({ rejectUnauthorized: false });
-  if (args[0].includes('https://localhost')) {
+  const allowLocalhost = 'https://localhost';
+  if (args[0].includes(allowLocalhost)) {
     requestInit.agent = httpsAgent;
   }
 

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -45,7 +45,9 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
     // eslint-disable-next-line typescript/no-var-requires
     const https = require('https');
     const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
     requestInit.agent = httpsAgent;
+
     return nodeFetch(urlOrRequest, requestInit);
   }
 

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -40,13 +40,13 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   const [urlOrRequest, requestInit = {}] = args;
 
   // Https localhost
-  // eslint-disable-next-line typescript/no-var-requires
-  const https = require('https');
-  const httpsAgent = new https.Agent({ rejectUnauthorized: false });
   const allowLocalhost = 'https://localhost';
-
-  if (args[0].includes(allowLocalhost)) {
+  if (!process.env.HTTPS_PROXY && urlOrRequest.includes(allowLocalhost)) {
+    // eslint-disable-next-line typescript/no-var-requires
+    const https = require('https');
+    const httpsAgent = new https.Agent({ rejectUnauthorized: false });
     requestInit.agent = httpsAgent;
+    return nodeFetch(urlOrRequest, requestInit);
   }
 
   // No Proxy
@@ -54,6 +54,7 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   if (!process.env.HTTPS_PROXY || (process.env.NO_PROXY && url.includes(process.env.NO_PROXY))) {
     return nodeFetch(...args);
   }
+
   // URL is first param attach the proxy
   // to the RequestInit
   // eslint-disable-next-line typescript/no-var-requires


### PR DESCRIPTION
Resolve #XXX

### Description
To allow connections from services on HTTPS localhost, we added a validation placed on top of the fetch requests that injects an HTTPS agent when the Emulator prompts a request to the localhost port. 

### Changes made

- Add https agent for localhost request
- Fix typescript/no-var-requires when require HTTPS

### Testing
![image](https://user-images.githubusercontent.com/37461749/63527176-f7be4c80-c4d6-11e9-9742-e94f837a5822.png)

