### PR TITLE
Enable copy the activities in JSON format

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.tsx
@@ -158,6 +158,23 @@ describe('<ChatContainer />', () => {
     });
   });
 
+  describe('activityWrapper', () => {
+    it('Should display the context menu for the activities in default mode', () => {
+      const dispatchSpy: jest.SpyInstance = jest.spyOn(mockStore, 'dispatch').mockReturnValue(true);
+      const next = () => (kids: any) => kids;
+      const card = { activity: { id: 'activity-id' } };
+      const children = 'a child node';
+      const webChat = render({} as any).find(ReactWebChat);
+      const middleware = webChat.prop('activityMiddleware') as any;
+      const activityWrapper = mount(middleware()(next)(card)(children));
+
+      // show context menu for activity
+      dispatchSpy.mockClear();
+      activityWrapper.simulate('contextmenu', { target: { tagName: 'DIV', classList: [] } });
+      expect(dispatchSpy).toHaveBeenCalledWith(showContextMenuForActivity(card.activity));
+    });
+  });
+
   describe('activity middleware', () => {
     it('renders an ActivityWrapper with the contents as children', () => {
       const next = () => (kids: any) => kids;

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -138,6 +138,7 @@ export class Chat extends Component<ChatProps, ChatState> {
         data-activity-id={card.activity.id}
         onClick={this.onItemRendererClick}
         onKeyDown={this.onItemRendererKeyDown}
+        onContextMenu={this.onContextMenu}
         isSelected={this.shouldBeSelected(card.activity)}
       >
         {next(card)(children)}

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
@@ -30,6 +30,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import * as Electron from 'electron';
 import {
   CommandServiceImpl,
   CommandServiceInstance,
@@ -89,6 +90,7 @@ jest.mock('electron', () => ({
       },
     }
   ),
+  clipboard: { writeText: (textFromActivity: string) => true },
 }));
 
 const mockState = {
@@ -504,6 +506,27 @@ describe('The Inspector component', () => {
         expect(dispatchSpy).toHaveBeenCalledWith(
           executeCommand(true, SharedConstants.Commands.Telemetry.TrackEvent, null, ...event.args)
         );
+      });
+    });
+
+    describe('should handle the accessory Click event', () => {
+      let instance;
+      let event;
+
+      beforeEach(() => {
+        instance = node.instance();
+        event = { channel: '', currentTarget: { dataset: { currentState: 'default' }, name: '' } };
+      });
+
+      it('"when the copy json button is clicked"', () => {
+        event.channel = 'proxy';
+        event.currentTarget.name = 'copyJson';
+        const spy = jest.spyOn(instance, 'accessoryClick');
+        const clipboardSpy = jest.spyOn(Electron.clipboard, 'writeText');
+        instance.accessoryClick(event);
+
+        expect(spy).toHaveBeenCalledWith(event);
+        expect(clipboardSpy).toHaveBeenCalledWith(JSON.stringify(instance.state.inspectObj, null, 2));
       });
     });
   });

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
@@ -519,12 +519,12 @@ describe('The Inspector component', () => {
       });
 
       it('"when the copy json button is clicked"', () => {
-        event.channel = 'proxy';
-        event.currentTarget.name = 'copyJson';
         const spy = jest.spyOn(instance, 'accessoryClick');
         const clipboardSpy = jest.spyOn(Electron.clipboard, 'writeText');
-        instance.accessoryClick(event);
 
+        event.channel = 'proxy';
+        event.currentTarget.name = 'copyJson';
+        instance.accessoryClick(event);
         expect(spy).toHaveBeenCalledWith(event);
         expect(clipboardSpy).toHaveBeenCalledWith(JSON.stringify(instance.state.inspectObj, null, 2));
       });

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -33,7 +33,7 @@
 
 // Cheating here and pulling in a module from node. Can be easily replaced if we ever move the emulator to the web.
 // @ts-ignore
-import * as Electron from 'electron';
+import { clipboard } from 'electron';
 import {
   EmulatorChannel,
   ExtensionChannel,
@@ -368,7 +368,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     const id = event.currentTarget.name;
 
     if (id == 'copyJson') {
-      return Electron.clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
+      return clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
     }
 
     const { currentState } = event.currentTarget.dataset;

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -370,6 +370,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     if (id == 'copyJson') {
       return Electron.clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
     }
+
     const { currentState } = event.currentTarget.dataset;
     this.sendToExtension(ExtensionChannel.AccessoryClick, id, currentState);
   };

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -33,6 +33,7 @@
 
 // Cheating here and pulling in a module from node. Can be easily replaced if we ever move the emulator to the web.
 // @ts-ignore
+import * as Electron from 'electron';
 import {
   EmulatorChannel,
   ExtensionChannel,
@@ -365,6 +366,10 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
 
   private accessoryClick = (event: MouseEvent<HTMLButtonElement>): void => {
     const id = event.currentTarget.name;
+
+    if (id == 'copyJson') {
+      return Electron.clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
+    }
     const { currentState } = event.currentTarget.dataset;
     this.sendToExtension(ExtensionChannel.AccessoryClick, id, currentState);
   };

--- a/packages/extensions/json/bf-extension.json
+++ b/packages/extensions/json/bf-extension.json
@@ -81,6 +81,18 @@
                 "aria-disabled": true
               }
             }
+          },
+          {
+            "id": "copyJson",
+            "states": {
+              "default": {
+                "label": "Copy json"
+              },
+              "selected": {
+                "label": "Copy json",
+                "aria-selected": true
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
Solves #XXX

### Description
Allows the users to copy the activities in JSON format using the _"Copy json"_ button placed in the inspector panel or using the context menu items for the activities in the chat session. 

### Changes made
- Add _"Copy json"_ button
- Add test for context menu displayed for the activities in default mode
- Enable context menu for activities in default mode 
- Add test when the "Copy json" button is clicked

### Testing
The next image shows how the "Copy json" button works.
![image](https://user-images.githubusercontent.com/37461749/63946983-7b82b680-ca4c-11e9-8d61-1dcc5db6e6fc.png)

Also, this one shows the context menu enabled for the activities in default mode.
![image](https://user-images.githubusercontent.com/37461749/63947270-fd72df80-ca4c-11e9-8968-2f20af91bb4c.png)