### PR TITLE
[ISSUE#1774] Update dirty on state when clicking on save button

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -300,6 +300,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     const newState = keys.reduce((s, key) => ((s[key] = settings[key]), s), {}) as FrameworkSettings;
     newState.hash = await generateHash(newState);
 
+    this.setState({ dirty: false });
     this.props.saveFrameworkSettings(newState);
   };
 


### PR DESCRIPTION
Solves #xxxx

### Description

The save button wasn't updating the `dirty` variable, so it didn't  change its state. 

### Changes made

- Update `dirty` on state when clicking on save button 

### Testing

![Issue1774-Solved](https://user-images.githubusercontent.com/37625424/64269189-dcf4ca80-cf0f-11e9-95c9-7fdf3a5fdae0.gif)


