### PR TITLE
[MAS4.1.2] [Screen Reader-Debug] Screen reader is not reading the state for Expanded or collapsed control

### DIFF
--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -178,6 +178,7 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
     }
     const proposedAriaExpandedValue = !(ul.getAttribute('aria-expanded') === 'true');
     ul.setAttribute('aria-expanded', proposedAriaExpandedValue.toString());
+    target.setAttribute('aria-expanded', proposedAriaExpandedValue.toString());
   };
 
   private focusNext(event: KeyboardEvent): void {

--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation
 // All rights reserved.
 //
-// MIT License:
+// MIT License:fa
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -83,6 +83,9 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
           }
           if (node.parentElement.getAttribute('aria-expanded') === 'false') {
             node.parentElement.setAttribute('aria-expanded', 'true');
+          }
+          if (node.parentElement.getAttribute('role') === 'tree') {
+            node.setAttribute('aria-expanded', 'true');
           }
           break;
 

--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -72,7 +72,12 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
           node.setAttribute('role', 'treeitem');
           // If we have a nested <ul>, this is a node and
           // should have a tab index
-          node.tabIndex = node.querySelector('ul') ? 0 : -1;
+          if (node.querySelector('ul')) {
+            node.tabIndex = 0;
+            node.setAttribute('aria-expanded', 'false');
+          } else {
+            node.tabIndex = -1;
+          }
           if (node.children.length) {
             this.nodesAdded(node.childNodes);
           }


### PR DESCRIPTION
Solves #xxxx

### Description

With this PR we enabled the screen reader to identify when the elements of the JSON viewer extension are `expanded` and `collapsed`.

### Changes made

- Screen reader reads collapse/expand

Since the screen reader wasn't reading the `aria-expanded` property from the `ul` tags, we added that property to the parent `li`