### PR TITLE
[MAS1.3.1][Screen Reader-Connect the bot] Incorrect position of the controls are announced by voiceover for the buttons available at the top most menu bar.

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -302,14 +302,13 @@ export class Emulator extends React.Component<EmulatorProps, {}> {
                   onClick={this.onStartOverClick}
                   buttonRef={this.setRestartButtonRef}
                 />
-                <div role="menuitem">
-                  <button
-                    className={`${styles.saveIcon} ${styles.toolbarIcon || ''}`}
-                    onClick={this.onExportTranscriptClick}
-                  >
-                    Save transcript
-                  </button>
-                </div>
+                <button
+                  role={'menuitem'}
+                  className={`${styles.saveIcon} ${styles.toolbarIcon || ''}`}
+                  onClick={this.onExportTranscriptClick}
+                >
+                  Save transcript
+                </button>
               </>
             )}
           </ToolBar>

--- a/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
+++ b/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
@@ -93,7 +93,7 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
           >
             <span>{defaultLabel}</span>
           </button>
-          <div className={styles.separator} />
+          <div className={styles.separator} aria-hidden={'true'} />
           <button
             aria-label={defaultLabel}
             className={styles.caretButton + expandedClass}


### PR DESCRIPTION
Solves # 1896

### Description
Fixes how voiceover announces the position of the editor menu bar's buttons controls

### Changes made
We added an `aria-hidden` attribute to the separator bar between the `restart conversation` button and the sub-menu button. This way voiceover skips this element which was causing the problem.

Additionally, we noticed that in windows, the last element of the menu bar was not being announced as 3/3. To solve this we removed a `div` around the `save transcript` button and moved the role label `menuitem` inside it.

### Testing
In the next image, you can see the voiceover reading the order of the elements as intended.

![asda](https://user-images.githubusercontent.com/38112957/67229181-2c844c80-f411-11e9-8ee2-d98be9d7ed18.gif)