### PR TITLE
[MAS2.4.6] [Headings and Labels - Open Bot Dialog] Heading should be defined for the pop-up or dialog

### DIFF
--- a/packages/sdk/ui-react/src/widget/dialog/dialog.scss
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.scss
@@ -90,3 +90,11 @@
     outline-color: var(--global-focus-outline-color);
   }
 }
+
+.dialog-header {
+  font-family: var(--default-font-family);
+  font-size: 22px;
+  font-weight: 200;
+  margin: 0px 4px 0px 0px;
+  padding: 0;
+}

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.scss.d.ts
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.scss.d.ts
@@ -4,3 +4,4 @@ export const dialog: string;
 export const footer: string;
 export const cancelButton: string;
 export const cancelButtonOutline: string;
+export const dialogHeader: string;

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -60,11 +60,11 @@ export class Dialog extends Component<ModalProps, {}> {
           onKeyDown={this.bodyKeyDownHandler}
           role="dialog"
         >
+          <h1 id="dialog-heading" className={`${titleClassName} ${styles.dialogHeader}`}>
+            {title}
+          </h1>
           <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
           <div className={styles.cancelButtonOutline} role="presentation"></div>
-          <header className={`${titleClassName}`} id="dialog-heading">
-            <h1 className={styles.dialogHeader}>{title}</h1>
-          </header>
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter, true))}
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter))}
         </div>

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -63,7 +63,7 @@ export class Dialog extends Component<ModalProps, {}> {
           <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
           <div className={styles.cancelButtonOutline} role="presentation"></div>
           <header className={`${titleClassName}`} id="dialog-heading">
-            {title}
+            <h1 className={styles.dialogHeader}>{title}</h1>
           </header>
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter, true))}
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter))}


### PR DESCRIPTION
Solves # 1899

### Description
Fixes how voiceover announces the heading for the pop-up or dialogs, by updating this component all the dialog titles will be announced.

### Changes made
We updated the dialog component to use an `<h1>` HTML tag for heading.

### Test
Now, the voiceover is reading the title of the dialog before announcing the content.

![image](https://user-images.githubusercontent.com/38112957/67297763-bb9c6d80-f4c0-11e9-8a89-d13cfa770e5e.png)
![image](https://user-images.githubusercontent.com/38112957/67297789-c35c1200-f4c0-11e9-925e-6898a6e70a8a.png)
![image](https://user-images.githubusercontent.com/38112957/67297807-c951f300-f4c0-11e9-9c67-85b56b57580b.png)

