### PR TITLE
[ISSUE#1906][Functional][Keyboard- Add QnA maker] The "Connect to QnA...." button is not functioning as well as after clicking on the same, "+" button in the service drop down is also not accessible with mouse nor with keyboard.

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
@@ -228,24 +228,20 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
 
   private get luisAndDispatchHeader(): ReactNode {
     const { serviceType } = this.props;
-    const textString = 'Learn more about keys in ' + labelMap[serviceType].toString();
     return (
       <p>
         {`You can find your LUIS app ID and subscription key in ${portalMap[serviceType]}. `}
-        <LinkButton className={styles.link} linkRole={true} onClick={this.learnMoreLinkButton}>
-          {textString}
-        </LinkButton>
+        {this.learnMoreLinkButton()}
       </p>
     );
   }
 
   private get qnaHeader(): ReactNode {
     const { serviceType } = this.props;
-
     return (
       <p>
         {`You can find your knowledge base ID and subscription key in ${portalMap[serviceType]}. `}
-        {this.learnMoreLinkButton}
+        {this.learnMoreLinkButton()}
       </p>
     );
   }
@@ -258,7 +254,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
           Azure Portal.
         </LinkButton>
         <br />
-        {this.learnMoreLinkButton}
+        {this.learnMoreLinkButton()}
       </p>
     );
   }
@@ -271,7 +267,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
           Azure Portal.
         </LinkButton>
         <br />
-        {this.learnMoreLinkButton}
+        {this.learnMoreLinkButton()}
       </p>
     );
   }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
@@ -392,9 +392,12 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
   private onSaveClick = (): void => {
     if (this.state.connectedServiceCopy.type === 'qna') {
       const validHostname = new RegExp('http(s?)://*');
+
       if (!validHostname.test(this.state.connectedServiceCopy['hostname'])) {
         const updatedConnectedServiceCopy = this.state.connectedServiceCopy;
-        updatedConnectedServiceCopy['hostname'] = 'http://' + this.state.connectedServiceCopy['hostname'];
+        const linkProtocol = 'http://';
+
+        updatedConnectedServiceCopy['hostname'] = linkProtocol + this.state.connectedServiceCopy['hostname'];
         this.setState({ connectedServiceCopy: updatedConnectedServiceCopy });
       }
     }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
@@ -100,14 +100,16 @@ const portalMap = {
 export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProps, ConnectedServiceEditorState> {
   constructor(props: ConnectedServiceEditorProps, state: ConnectedServiceEditorState) {
     super(props, state);
-    this.state = {
-      connectedServiceCopy: BotConfigurationBase.serviceFromJSON(
-        props.connectedService || {
-          type: props.serviceType,
-          name: '',
-        }
-      ),
-    };
+    if (props.serviceType === 'qna' && props.connectedService === undefined) {
+      this.state = { connectedServiceCopy: new ConnectedService() };
+      this.state.connectedServiceCopy.type = ServiceTypes.QnA;
+    } else {
+      this.state = {
+        connectedServiceCopy: BotConfigurationBase.serviceFromJSON(
+          props.connectedService || { type: props.serviceType, name: '' }
+        ),
+      };
+    }
   }
 
   public render(): JSX.Element {
@@ -388,6 +390,14 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
   private onAzurePortalClick = this.createAnchorClickHandler('https://portal.azure.com');
 
   private onSaveClick = (): void => {
+    if (this.state.connectedServiceCopy.type === 'qna') {
+      const validHostname = new RegExp('http(s?)://*');
+      if (!validHostname.test(this.state.connectedServiceCopy['hostname'])) {
+        const updatedConnectedServiceCopy = this.state.connectedServiceCopy;
+        updatedConnectedServiceCopy['hostname'] = 'http://' + this.state.connectedServiceCopy['hostname'];
+        this.setState({ connectedServiceCopy: updatedConnectedServiceCopy });
+      }
+    }
     this.props.updateConnectedService(this.state.connectedServiceCopy);
   };
 


### PR DESCRIPTION
Solves # 1906

### Description
This pull request fixes the `add a qna service manually` dialog, now the dialog opens correctly and lets the user add QnA Services.

Also, fixes the header and links of all the `add service manually`, before this changes, the dialogs were omitting a part of the header with a link to more information and the links from LUIS and dispatch dialogs.

Finally, the tester mentions that some links inside the `Get started with channel` section are not working properly. This section reads an MD file from [this url](https://raw.githubusercontent.com/Microsoft/BotFramework-Emulator/master/content/CHANNELS.md) in the master branch. We will be treating this as a different issue, for which we will be creating another pull request with the solution.

### Changes made
For the first issue about the add qna service manually dialog, we found we are creating a new `qnaMakerService` from the `BotFramework-config` dependency, getting an error for not providing a hostname. We still need to create this service to add the hostname later.

Also, the dialog was throwing an internal error when we tried to save the new qna service using an invalid format of hostname (not starting with http:// or https://), to solve this we added a validation and added an http:// at the beginning of the provided hostname when it was missing. These changes should be treated as a hotfix, since the problem is being caused by the dependency that should allows to create a `qnaMakerService` without a hostname, to set it later and also handle invalid formats.

When looking if this is a known issue, we found the ISSUE#939 `https://github.com/microsoft/botbuilder-js/issues/939` but it was already closed with the PR#1035 `https://github.com/microsoft/botbuilder-js/pull/1035`, where it states that the hostname can never be empty.

Regarding the second part, about the headers in the dialogs, we found we had a method to render the header but was being called incorrectly, thus, not being created.
Also, regarding the links in the dispatch and LUIS dialogs, we had the headers created manually getting a call to this mentioned method as it was a link, but instead it creates the whole header.

### Testing
Here you can see the `add qna service manually` dialog working.
![qnamanual5](https://user-images.githubusercontent.com/38112957/68599960-59f86f00-0480-11ea-9bf4-df8d81dccb7d.gif)

And in the next image, you can see the missing part added to the headers. This change also fixes the links previously not working.
![image](https://user-images.githubusercontent.com/38112957/68600012-75637a00-0480-11ea-802a-73560de85ddf.png)