### PR TITLE
Fix non functional zoom in/zoom out feature in Emulator window

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -151,14 +151,13 @@ export class AppMenuTemplate {
         label: 'Zoom In',
         onClick: () => {
           const webContents = remote.getCurrentWebContents();
-          webContents.getZoomFactor(zoomFactor => {
-            const newZoomFactor = zoomFactor + 0.1;
-            if (newZoomFactor >= maxZoomFactor) {
-              webContents.setZoomFactor(maxZoomFactor);
-            } else {
-              webContents.setZoomFactor(newZoomFactor);
-            }
-          });
+          const zoomFactor = webContents.getZoomFactor();
+          const newZoomFactor = zoomFactor + 0.1;
+          if (newZoomFactor >= maxZoomFactor) {
+            webContents.setZoomFactor(maxZoomFactor);
+          } else {
+            webContents.setZoomFactor(newZoomFactor);
+          }
         },
         subtext: `${CtrlOrCmd}+=`,
       },
@@ -166,14 +165,13 @@ export class AppMenuTemplate {
         label: 'Zoom Out',
         onClick: () => {
           const webContents = remote.getCurrentWebContents();
-          webContents.getZoomFactor(zoomFactor => {
-            const newZoomFactor = zoomFactor - 0.1;
-            if (newZoomFactor <= minZoomFactor) {
-              webContents.setZoomFactor(minZoomFactor);
-            } else {
-              webContents.setZoomFactor(newZoomFactor);
-            }
-          });
+          const zoomFactor = webContents.getZoomFactor();
+          const newZoomFactor = zoomFactor - 0.1;
+          if (newZoomFactor <= minZoomFactor) {
+            webContents.setZoomFactor(minZoomFactor);
+          } else {
+            webContents.setZoomFactor(newZoomFactor);
+          }
         },
         subtext: `${CtrlOrCmd}+-`,
       },


### PR DESCRIPTION
Fixes MS63986

This PR fixes the non functional zooming in - out feature in Emulator, as reported by issue:
"Zoom in, Zoom out' control of 'View' menu is not performing any action when activated with keyboard or mouse"

Method viewMenu in class [appMenuTemplate](https://github.com/microsoft/BotFramework-Emulator/blob/main/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts#L149) had errors as marked by the IDE, erroneously passing a parameter to the webContents.getZoomFactor method
![image](https://user-images.githubusercontent.com/20074735/132559088-80c8a6b2-e656-42af-a2f9-c5ace0a468b6.png)
 