### PR TITLE
Fix wrong header level in Ngrok status screen

### DIFF
--- a/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
+++ b/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
@@ -134,8 +134,8 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
         <Column>
           <section>
             <SmallHeader>Tunnel Health</SmallHeader>
-            <ul className={styles.tunnelDetailsList}>
-              <li>
+            <div className={styles.tunnelDetailsList}>
+              <div>
                 <span>
                   <NgrokStatusIndicator
                     tunnelStatus={props.tunnelStatus}
@@ -143,15 +143,15 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
                     header="Tunnel Status"
                   />
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 <LinkButton linkRole={true} onClick={props.onPingTunnelClick}>
                   Click here
                 </LinkButton>
                 &nbsp;to ping the tunnel now
-              </li>
+              </div>
               {errorDetailsContainer}
-            </ul>
+            </div>
           </section>
           {props.publicUrl ? tunnelConnections : null}
         </Column>


### PR DESCRIPTION
Fixes MS63975

### Description
As reported by the issue, Improper heading label is defined on 'Ngrok status' screen for 'Tunnel Health' and 'Tunnel Status' text, causing Narrator to assign a wrong Header 1 level to the text in NgrokStatusIndicator as seen in the picture.

### Changes made
We changed the Unordered List in the NgrokStatusIndicator component to a div with spans.

### Testing
No unit tests needed to be modified for this change.

![image](https://user-images.githubusercontent.com/20074735/133306139-6a11bb45-583a-4e7a-a091-150b9265da03.png)


