### PR TITLE
Fix focus on Services list after sorting the elements

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -49,6 +49,7 @@ export interface ServicePaneProps extends ServicePaneState {
 
 export interface ServicePaneState {
   expanded?: boolean;
+  sortCriteriaChanged?: boolean;
 }
 
 /* eslint-disable react/display-name */
@@ -108,12 +109,13 @@ export abstract class ServicePane<
 
   protected get content(): JSX.Element {
     const { links, additionalContent } = this;
+    const { sortCriteriaChanged } = this.state;
+
     if (!links || !links.length) {
       return <ExpandCollapseContent>{this.emptyContent}</ExpandCollapseContent>;
     }
-    debugger;
-    if (this.props.sortCriteria && this.listRef) {
-      this.listRef.focus();
+    if (sortCriteriaChanged) {
+      this.listRef && this.listRef.focus();
     }
     return (
       <ExpandCollapseContent>

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -117,7 +117,7 @@ export abstract class ServicePane<
     }
     return (
       <ExpandCollapseContent>
-        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)} tabindex={0}>
+        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)} tabIndex={0}>
           {links}
         </ul>
         {additionalContent}

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -111,9 +111,13 @@ export abstract class ServicePane<
     if (!links || !links.length) {
       return <ExpandCollapseContent>{this.emptyContent}</ExpandCollapseContent>;
     }
+    debugger;
+    if (this.props.sortCriteria && this.listRef) {
+      this.listRef.focus();
+    }
     return (
       <ExpandCollapseContent>
-        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)}>
+        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)} tabindex={0}>
           {links}
         </ul>
         {additionalContent}

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -188,7 +188,6 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
           onKeyPress={this.onKeyPress}
           data-index={index}
           tabIndex={0}
-          title={service.name}
         >
           {iconMap[service.type]}
           {label}{' '}

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -120,6 +120,10 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
       }
       return 0;
     });
+
+    // Check if the sortCriteria has changed
+    state.sortCriteriaChanged = existingProps.sortCriteria != newProps.sortCriteria;
+
     return state;
   }
 


### PR DESCRIPTION
Fixes MS63970

### Description
As reported by the issue, Narrator was not being able to read the Services list after modifying the sort criteria.

### Changes made
We changed the focus to the Services list after the sort criteria changes, also we added a tabIndex in order to make the Narrator able to read the elements when diving through the list.

### Testing
No unit tests needed to be modified for this change.

![image](https://user-images.githubusercontent.com/64086728/133626224-c679ae49-e7aa-46d9-a1e4-0fb11372e695.png)
