### PR TITLE
Add ARIA audio alert for changing themes

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -36,6 +36,8 @@ import { BotInfo, SharedConstants, UpdateStatus } from '@bfemulator/app-shared';
 import { MenuButton, MenuItem } from '@bfemulator/ui-react';
 import { BotConfigWithPath } from '@bfemulator/sdk-shared';
 
+import { ariaAlertService } from '../../a11y';
+
 import * as styles from './appMenu.scss';
 import { AppMenuTemplate } from './appMenuTemplate';
 
@@ -113,6 +115,7 @@ export class AppMenu extends React.Component<AppMenuProps, Record<string, unknow
         label: theme.name,
         checked: theme.name === currentTheme,
         onClick: () => {
+          ariaAlertService.alert('Theme ' + theme.name + ' has been applied successfully.');
           this.props.switchTheme(theme.name);
         },
       };


### PR DESCRIPTION
Fixes MS63983

### Description
As reported by the issue, the theme change in Emulator was not announced by ARIA with an audio alert.

### Changes made
Added a call to ariaAlertService when switching the theme.

### Testing
No changes to unit tests needed to be done
![image](https://user-images.githubusercontent.com/20074735/133627460-7cd1e905-20c0-44d9-81e1-53b90bce48d7.png)

