### PR TITLE
Fix Hide button focus on Narrator

### DIFF
--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -135,6 +135,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             type={revealSecret ? 'text' : 'password'}
           />
           <ul className={styles.actionsList}>
+            <div></div>
             <li>
               <LinkButton className={styles.dialogLink} disabled={!encryptKey} onClick={this.onRevealSecretClick}>
                 {revealSecret ? 'Hide' : 'Show'}


### PR DESCRIPTION
Fixes MS63979

### Description
As reported by the issue, In scan mode, Narrator remains silent when the focus is on 'Hide' button under setting dialog.

### Changes made
We added a "div" before the Hide button to avoid Narrator focus being stuck on the textBox before.

### Testing
No unit tests needed to be modified for this change.
![image](https://user-images.githubusercontent.com/64086728/133674525-76d1c191-5c17-4b49-9dc7-b560a40e46e6.png)
