### PR TITLE
Fix hide button focus on narrator

### DIFF
--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -135,6 +135,8 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             type={revealSecret ? 'text' : 'password'}
           />
           <ul className={styles.actionsList}>
+            <div>
+            </div>
             <li>
               <LinkButton className={styles.dialogLink} disabled={!encryptKey} onClick={this.onRevealSecretClick}>
                 {revealSecret ? 'Hide' : 'Show'}


### PR DESCRIPTION
Fixes MS63979

### Description
As reported by the issue, In scan mode, Narrator remains silent when the focus is on 'Hide' button under setting dialog.

### Changes made
We added a "div" before the Hide button to avoid Narrator focus being stuck on the textBox before.

### Testing
No unit tests needed to be modified for this change
![image (83)](https://user-images.githubusercontent.com/64086728/133801928-cf6b5735-0b13-4af5-81d3-cfc445fdf9e0.png)
