### PR TITLE
Fix bot URL role

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -82,7 +82,6 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
       <div
         className={`${styles.autoCompleteContainer} ${invalidClassName} ${className}`}
         id={this.textboxId}
-        role="combobox"
         aria-expanded={this.state.showResults}
         aria-haspopup="listbox"
         aria-owns={this.listboxId}


### PR DESCRIPTION
Fixes MS63984

### Description
As reported by the issue, inside the open a bot pop up, the Bot URL field was being read as "Combo Edit" by Narrator.

### Changes made
We the role in autoComplete class to avoid Narrator reading it as "Combo Edit" instead of reading it as "Edit".

### Testing
No unit tests needed to be modified for this change
![image (84)](https://user-images.githubusercontent.com/64086728/134191904-2e6f414a-ac2b-4761-97b2-5a262e946520.png)
