### PR TITLE
Enable Narrator arrow navigation in 'Open a Bot' dialog 

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -154,7 +154,6 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               label={'Bot URL'}
               items={savedBotUrls.map(elem => elem.url).slice(0, 9)}
               onChange={this.onBotUrlChange}
-              placeholder={'Enter your bot URL'}
               value={this.state.botUrl}
             />
             {this.browseButton}
@@ -167,6 +166,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               onChange={this.onInputChange}
               placeholder="Optional"
               value={appId}
+              aria-hidden={true}
             />
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
@@ -176,6 +176,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="password"
               value={appPassword}
+              aria-hidden={true}
             />
           </Row>
           {!isDebug && (
@@ -187,6 +188,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
                 onChange={this.onInputChange}
                 placeholder="Optional"
                 value={speechRegion}
+                aria-hidden={true}
               />
               <TextField
                 inputContainerClassName={openBotStyles.inputContainerRow}
@@ -196,6 +198,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
                 placeholder="Optional"
                 type="password"
                 value={speechKey}
+                aria-hidden={true}
               />
             </Row>
           )}
@@ -208,6 +211,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomSeed}
+              aria-hidden={true}
             />
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
@@ -217,6 +221,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomValue}
+              aria-hidden={true}
             />
           </Row>
           <Row className={openBotStyles.rowOverride}>

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -62,7 +62,7 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
     super(props);
 
     this.state = {
-      currentInput: '',
+      currentInput: ' ',
       id: AutoComplete.getId(),
       selectedIndex: undefined,
       showResults: false,
@@ -185,7 +185,7 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
 
   private get value(): string {
     // if in 'controlled mode,' an empty string should be a valid input
-    if (this.props.value === '') {
+    if (this.props.value === ' ') {
       return this.props.value;
     }
     return this.props.value || this.state.currentInput;


### PR DESCRIPTION
Fixes MS63968

### Description
As reported by the issue, when navigating the Open a Bot screen in Scan Mode with the down arrow, navigation would get stuck at the Bot Url combobox.

### Changes made
Changed the default field value from '' to ' ' in order to workaround the unresponsive navigation.

### Testing
