### PR TITLE
Fix luminosity ratio and outline offset on open bot button

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -57,6 +57,7 @@
   margin-top: 24px;
   margin-bottom: 16px;
   width: 180px;
+  outline-offset: 2px;
 }
 
 .cta-link {

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -115,7 +115,7 @@ html {
   --p-button-color: var(--neutral-2);
   --p-button-color-disabled: var(--neutral-6);
   --p-button-border: 1px solid transparent;
-  --p-button-border-focus: 1px solid #00BCF2;
+  --p-button-border-focus: 1px solid #007ACC;
   --p-button-border-hover: 1px solid transparent;
   --p-button-border-active: 1px solid transparent;
   --p-button-border-disabled: 1px solid transparent;


### PR DESCRIPTION
Fixes MS63942

### Description
As reported by the issue, Luminosity ratio was less than 3:1 for 'open bot' button focus, also we received an email asking to change the outline offset.

### Changes made
We changed the focus outline color to be #007ACC and also added an outline offset of 2px.

### Testing
No unit tests needed to be modified for this change
![image](https://user-images.githubusercontent.com/64086728/134517428-9c68d4dd-a8e6-479f-888e-d5131a75efee.png)
