### PR TITLE
Fix wrong luminosity ratio in dropdown icon in 'Restart Conversation' button

### DIFF
--- a/packages/app/client/src/ui/styles/themes/neutral.css
+++ b/packages/app/client/src/ui/styles/themes/neutral.css
@@ -7,7 +7,7 @@ html {
   --neutral-15: #212121;
   --neutral-14: #333333;
   --neutral-13: #444;
-  --neutral-12: #4a4a4a;
+  --neutral-12: #605e5c;
   --neutral-11: #515151;
   --neutral-10: #666;
   --neutral-9: #777;


### PR DESCRIPTION
Fixes MS63950

### Description
As reported by the issue, the luminosity ratio between the 'chevron down' icon for opening the dropdown at the 'Restart Conversation' button was lower than accepted.

### Changes made
We changed the previous color ##4a4a4a to #605e5c as suggested by the design team.

### Testing
There were no need to update unit tests.