### PR TITLE
Fix focus color and outline offset for buttons in Emulator

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
@@ -65,6 +65,7 @@
     &:focus ~ label {
       outline: 1px solid var(--dialog-link-focus-color);
       background-color: var(--p-button-bg-focus);
+      outline-offset: 2px;
     
       &::after {
         border: var(--p-button-border-focus);

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
@@ -93,5 +93,5 @@
 }
 
 .spacing {
-  padding: 0 0 2px 3px;
+  padding: 0 0 3px 3px;
 }

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -279,7 +279,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
             </fieldset>
           </Column>
         </Row>
-        <Row className={styles.buttonRow} justify={RowJustification.Right}>
+        <Row className={[styles.buttonRow, styles.spacing].join(' ')} justify={RowJustification.Right}>
           <PrimaryButton text="Cancel" onClick={this.props.discardChanges} className={styles.cancelButton} />
           <PrimaryButton
             text="Save"

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -168,7 +168,7 @@
 }
 
 .spacing {
-  padding: 0 0 2px 2px;
+  padding: 0 0 2px 3px;
 }
 
 .margin-fix {

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -2,7 +2,7 @@ html {
   /* Globals */
   --global-focus-outline-width: 1px;
   --global-focus-outline-style: solid;
-  --global-focus-outline-color: #1177BB;
+  --global-focus-outline-color: #007ACC;
   --box-shadow-color: var(--neutral-6);
 
   /* Highlight colors */

--- a/packages/sdk/ui-react/src/widget/button/button.scss
+++ b/packages/sdk/ui-react/src/widget/button/button.scss
@@ -45,6 +45,7 @@
 
   &:focus {
     background-color: var(--s-button-bg-focus);
+    outline-offset: 2px;
 
     &::after {
       border: var(--s-button-border-focus);
@@ -139,6 +140,7 @@
 
   &:focus {
     background-color: var(--p-button-bg-focus);
+    outline-offset: 2px;
 
     &::after {
       border: var(--p-button-border-focus);


### PR DESCRIPTION
Fixes MS63972

### Description

As reported by the issue, we had to add an outline offset to buttons when they are focused. Also, we have to change the color using the one specified by the designer.

### Changes made

- Added a 2px outline offset for buttons
- Added additional padding to make visible the outline for buttons
- Updated focus color to be compliant with the luminosity ratio criteria

### Testing

No test cases updated.

### Screenshots

Styles applied on a primary button
![imagen](https://user-images.githubusercontent.com/62261539/134594293-f3738600-63a0-4d53-ad8e-20bf6934c2cc.png)

Styles applied on a default button
![imagen](https://user-images.githubusercontent.com/62261539/134594344-270915e5-ed43-4510-812d-949bfedf70e4.png)
