### PR TITLE
Fix error 'An element of the given ControlType must support the Text pattern' in Bot Settings

### DIFF
--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -130,7 +130,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             label="Secret "
             placeholder="Your keys are not encrypted"
             value={secret}
-            disabled={true}
+            readOnly={true}
             id="key-input"
             type={revealSecret ? 'text' : 'password'}
           />


### PR DESCRIPTION
Fixes MS63992

### Description
As reported by the issue, the error 'An element of the given ControlType must support the Text pattern' would appear in the Accessibility Insights tool when examining the keys textfield in the Bot Settings screen, in discordance with section [508 502.3.10](https://www.access-board.gov/ict/#502.3.10) of US Access Board Accessibility rules

### Changes made
Changed the property enabled={true} to readOnly={true}.

### Testing
There were no need to update unit tests.