### PR TITLE
Fix lost focus when opening the Resource Settings dialog

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorer.tsx
@@ -64,6 +64,8 @@ export interface ResourceExplorerProps extends ServicePaneProps, ResourceExplore
 }
 
 export class ResourceExplorer extends ServicePane<ResourceExplorerProps, ResourceExplorerState> {
+  private chooseLocationButtonRef: HTMLButtonElement;
+
   constructor(props: ResourceExplorerProps, context: ResourceExplorerState) {
     super(props, context);
     this.state = {
@@ -154,6 +156,7 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
           ariaLabel="Choose a different location."
           className={styles.explorerLink}
           onClick={this.onChooseLocationClick}
+          buttonRef={this.setChooseLocationButtonRef}
         >
           <strong>Choose a different location.</strong>
         </LinkButton>
@@ -161,8 +164,9 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
     );
   }
 
-  private onChooseLocationClick = () => {
-    this.props.openResourcesSettings(ResourcesSettingsContainer);
+  protected onChooseLocationClick = async () => {
+    await this.props.openResourcesSettings(ResourcesSettingsContainer);
+    this.chooseLocationButtonRef && this.chooseLocationButtonRef.focus();
   };
 
   private onInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -198,4 +202,8 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
     }
     return fileToRename;
   }
+
+  private setChooseLocationButtonRef = (ref: HTMLButtonElement): void => {
+    this.chooseLocationButtonRef = ref;
+  };
 }

--- a/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorerContainer.ts
+++ b/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorerContainer.ts
@@ -32,6 +32,8 @@
 //
 import { IFileService } from 'botframework-config/lib/schema';
 import { ComponentClass } from 'react';
+import { ResourcesSettingsContainer } from '../../../dialogs';
+import { DialogService } from '../../../dialogs/service';
 import { connect } from 'react-redux';
 import {
   openContextMenuForResource,
@@ -53,7 +55,8 @@ const mapDispatchToProps = (dispatch: (...args: any[]) => void): ResourceExplore
   openContextMenuForService: (resource: IFileService) => dispatch(openContextMenuForResource(resource)),
   renameResource: resource => dispatch(renameResource(resource)),
   openResource: resource => dispatch(openResource(resource)),
-  openResourcesSettings: (dialog: ComponentClass<any>) => dispatch(openResourcesSettings({ dialog })),
+  openResourcesSettings: (dialog: ComponentClass<any>) =>
+    DialogService.showDialog(ResourcesSettingsContainer, openResourcesSettings({ dialog })).catch(),
   window,
 });
 


### PR DESCRIPTION
### Description

As reported by the issue, the focus was getting lost after clicking on the "Choose a different location" link button and closing the modal popup.

### Changes made

- Added an await call to the open dialog dispatch function and set the focus to the link button after the dialog is closed

### Testing

No test cases updated.

### Screenshots

After closing the modal dialog, the focus is properly set
![imagen](https://user-images.githubusercontent.com/62261539/134724888-6e556d50-2938-4b82-b34a-b1317443a064.png)
