### PR TITLE
Fix luminosity ratio of undefined text on json section

### DIFF
--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/themes/light.ts
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/themes/light.ts
@@ -46,7 +46,7 @@ export default {
   base05: background,
   base06: background,
   base07: background,
-  base08: '#f92672',
+  base08: '#605E5C',
   base09: booleanNumber,
   base0A: '#f4bf75',
   base0B: string,


### PR DESCRIPTION
Fixes MS63919

### Description
As reported by the issue, Luminosity ratio was less than 4.5:1 for ‘Undefined’ text on ‘JSON’ section under “Live Chat’ tab.

### Changes made
We changed the base08 color to be #605E5C.

### Testing
No unit tests needed to be modified for this change
![image](https://user-images.githubusercontent.com/64086728/134730055-97197f43-1f98-4e33-8636-6b7b24e27eff.png)