### PR TITLE
Fix focus when clicking on "Get Started with Channel (Bot Inspector)"

### DIFF
--- a/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
@@ -45,12 +45,19 @@ export interface MarkdownPageProps {
 
 export class MarkdownPage extends Component<MarkdownPageProps> {
   private static markdownRenderer = new MarkdownIt();
+  private botInspectorRef: HTMLInputElement;
 
   private static renderMarkdown(markdown: string) {
     try {
       return this.markdownRenderer.render(markdown);
     } catch (e) {
       return '# Error - Invalid markdown document';
+    }
+  }
+
+  public componentDidMount(): void {
+    if (this.botInspectorRef) {
+      this.botInspectorRef.focus();
     }
   }
 
@@ -78,9 +85,15 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
     ) : (
       <div
         className={styles.markdownContainer}
+        ref={this.setBotInspectorRef}
+        tabIndex={0}
         dangerouslySetInnerHTML={{ __html: MarkdownPage.renderMarkdown(this.props.markdown) }}
       />
     );
     return <GenericDocument>{children}</GenericDocument>;
   }
+
+  private setBotInspectorRef = (ref: HTMLInputElement): void => {
+    this.botInspectorRef = ref;
+  };
 }


### PR DESCRIPTION
Fixes MS63973

### Description
As reported by the issue, focus was not moving to ‘Get Started with Channel (Bot Inspector)’ tab section after selecting ‘Get Started with Channel (Bot Inspector)’ menu item from Help drop down list.

### Changes made
We added a ref inside the div of markdownPage.tsx in order to get the focus moved into ‘Get Started with Channel (Bot Inspector)’ after selecting it from the Help drop down list. For this, we componentDidMount() method in which the focus is set to the ref whenever the botInspectorRef is not null.

### Testing
No unit tests needed to be modified for this change
![image (89)](https://user-images.githubusercontent.com/64086728/135297957-87a4a8cd-91ea-4987-a390-a0976d5f5335.png)