### PR TITLE
Fix focusable sibling elements with the same type and value

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
@@ -227,9 +227,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     return (
       <span key={key} onMouseOver={() => this.highlight(obj)} onMouseLeave={() => this.highlight({})}>
         <span className={`inspectable-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspectAndHighlightInWebchat(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspectAndHighlightInWebchat(obj)}>
             {title}
-          </button>
+          </span>
         </span>
         <span className={`${styles.spaced} ${styles.level0}`}>{summaryText}</span>
       </span>
@@ -250,9 +250,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     if (obj) {
       return (
         <span key={key} className={`network-req-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspect(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspect(obj)}>
             {method}
-          </button>
+          </span>
         </span>
       );
     } else {
@@ -292,9 +292,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     if (obj) {
       return (
         <span key={key} className={`network-res-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspect(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspect(obj)}>
             {statusCode}
-          </button>
+          </span>
         </span>
       );
     } else {


### PR DESCRIPTION
Fixes MS63969

### Description

As reported by the issue, the link buttons used to inspect the messaged in the log panel were being reported sibling elements with the same name.

### Changes made

- Replaced the button elements with a span

### Testing

No need to update test cases.
![imagen](https://user-images.githubusercontent.com/62261539/135332124-cce65d79-4a08-4a40-881a-1f367f40cbdb.png)

### Screenshots

The issue is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/135332377-fd444dad-cb1e-45d4-b8b0-89e4af7d112b.png)

![imagen](https://user-images.githubusercontent.com/62261539/135332350-e79023aa-b013-48c5-a890-881fbb9e685c.png)
