### PR TITLE
Fix Accessibility Insights report about two empty text properties in Welcome Screen

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
@@ -161,7 +161,6 @@ export class HowToBuildABot extends React.Component<HowToBuildABotProps, Record<
                 >
                   Continuous Deployment
                 </LinkButton>
-                &nbsp;
               </p>
             </div>
           </div>
@@ -180,7 +179,6 @@ export class HowToBuildABot extends React.Component<HowToBuildABotProps, Record<
                 >
                   channels
                 </LinkButton>
-                &nbsp;
               </p>
             </div>
           </div>


### PR DESCRIPTION
Fixes MS63987

### Description
As reported by the issue, the error 'The Name property must not contain only space characters' is reported twice at the Welcome Screen.

### Changes made
Removed two non-breaking spaces present in the screen.

### Testing
There were no need to update unit tests.