### PR TITLE
Fix focus when opening or changing to Emulator Settings tab

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -55,7 +55,6 @@ import * as styles from './appSettingsEditor.scss';
 export interface AppSettingsEditorProps {
   documentId?: string;
   dirty?: boolean;
-  refocus?: boolean;
   framework?: FrameworkSettings;
   ngrokTunnelStatus?: TunnelStatus;
   ngrokLastPingInterval?: TunnelCheckTimeInterval;
@@ -72,7 +71,6 @@ export interface AppSettingsEditorProps {
 export interface AppSettingsEditorState extends Partial<FrameworkSettings> {
   dirty?: boolean;
   pendingUpdate?: boolean;
-  refocus?: boolean;
 }
 
 function shallowEqual(x: any, y: any) {
@@ -82,11 +80,6 @@ function shallowEqual(x: any, y: any) {
 export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, AppSettingsEditorState> {
   public state = {} as AppSettingsEditorState;
   private pathToNgrokInputRef: HTMLInputElement;
-
-  constructor(props) {
-    super(props);
-    this.state = { refocus: true };
-  }
 
   public static getDerivedStateFromProps(
     newProps: AppSettingsEditorProps,
@@ -106,7 +99,6 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     return {
       ...newProps.framework,
       dirty: newProps.dirty,
-      refocus: newProps.refocus,
       pendingUpdate: false,
     };
   }
@@ -136,12 +128,6 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     const inputProps = {
       disabled: !useCustomId,
     };
-
-    if (this.state.refocus) {
-      if (this.pathToNgrokInputRef) {
-        this.pathToNgrokInputRef.focus();
-      }
-    }
 
     return (
       <GenericDocument className={styles.appSettingsEditor}>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -55,6 +55,7 @@ import * as styles from './appSettingsEditor.scss';
 export interface AppSettingsEditorProps {
   documentId?: string;
   dirty?: boolean;
+  refocus?: boolean;
   framework?: FrameworkSettings;
   ngrokTunnelStatus?: TunnelStatus;
   ngrokLastPingInterval?: TunnelCheckTimeInterval;
@@ -71,6 +72,7 @@ export interface AppSettingsEditorProps {
 export interface AppSettingsEditorState extends Partial<FrameworkSettings> {
   dirty?: boolean;
   pendingUpdate?: boolean;
+  refocus?: boolean;
 }
 
 function shallowEqual(x: any, y: any) {
@@ -92,6 +94,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     return {
       ...newProps.framework,
       dirty: newProps.dirty,
+      refocus: newProps.refocus,
       pendingUpdate: false,
     };
   }
@@ -121,6 +124,11 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     const inputProps = {
       disabled: !useCustomId,
     };
+
+    if (this.state.refocus) {
+      this.pathToNgrokInputRef.focus();
+      this.setState({ refocus: false });
+    }
 
     return (
       <GenericDocument className={styles.appSettingsEditor}>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -83,6 +83,11 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
   public state = {} as AppSettingsEditorState;
   private pathToNgrokInputRef: HTMLInputElement;
 
+  constructor(props) {
+    super(props);
+    this.state = { refocus: true };
+  }
+
   public static getDerivedStateFromProps(
     newProps: AppSettingsEditorProps,
     prevState: AppSettingsEditorState

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -93,7 +93,14 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     prevState: AppSettingsEditorState
   ): AppSettingsEditorState {
     if (newProps.framework.hash === prevState.hash) {
-      return prevState;
+      if (newProps.dirty === prevState.dirty) {
+        return prevState;
+      } else {
+        return {
+          ...prevState,
+          dirty: newProps.dirty,
+        };
+      }
     }
 
     return {
@@ -104,7 +111,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     };
   }
 
-  public componentDidMount(): void {
+  public componentDidUpdate() {
     if (this.pathToNgrokInputRef) {
       this.pathToNgrokInputRef.focus();
     }

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -126,8 +126,9 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     };
 
     if (this.state.refocus) {
-      this.pathToNgrokInputRef.focus();
-      this.setState({ refocus: false });
+      if (this.pathToNgrokInputRef) {
+        this.pathToNgrokInputRef.focus();
+      }
     }
 
     return (

--- a/packages/app/client/src/ui/editor/editor.tsx
+++ b/packages/app/client/src/ui/editor/editor.tsx
@@ -63,7 +63,7 @@ export class EditorFactory extends React.Component<EditorFactoryProps> {
         );
 
       case Constants.CONTENT_TYPE_APP_SETTINGS:
-        return <AppSettingsEditorContainer documentId={document.documentId} dirty={true} refocus={true} />;
+        return <AppSettingsEditorContainer documentId={document.documentId} dirty={this.props.document.dirty} />;
 
       case Constants.CONTENT_TYPE_WELCOME_PAGE:
         return <WelcomePageContainer documentId={document.documentId} />;

--- a/packages/app/client/src/ui/editor/editor.tsx
+++ b/packages/app/client/src/ui/editor/editor.tsx
@@ -63,13 +63,7 @@ export class EditorFactory extends React.Component<EditorFactoryProps> {
         );
 
       case Constants.CONTENT_TYPE_APP_SETTINGS:
-        return (
-          <AppSettingsEditorContainer
-            documentId={document.documentId}
-            dirty={this.props.document.dirty}
-            refocus={true}
-          />
-        );
+        return <AppSettingsEditorContainer documentId={document.documentId} dirty={true} refocus={true} />;
 
       case Constants.CONTENT_TYPE_WELCOME_PAGE:
         return <WelcomePageContainer documentId={document.documentId} />;

--- a/packages/app/client/src/ui/editor/editor.tsx
+++ b/packages/app/client/src/ui/editor/editor.tsx
@@ -63,7 +63,13 @@ export class EditorFactory extends React.Component<EditorFactoryProps> {
         );
 
       case Constants.CONTENT_TYPE_APP_SETTINGS:
-        return <AppSettingsEditorContainer documentId={document.documentId} dirty={this.props.document.dirty} />;
+        return (
+          <AppSettingsEditorContainer
+            documentId={document.documentId}
+            dirty={this.props.document.dirty}
+            refocus={true}
+          />
+        );
 
       case Constants.CONTENT_TYPE_WELCOME_PAGE:
         return <WelcomePageContainer documentId={document.documentId} />;

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -45,6 +45,7 @@ import {
   CONTENT_TYPE_TRANSCRIPT,
   CONTENT_TYPE_WELCOME_PAGE,
   CONTENT_TYPE_NGROK_DEBUGGER,
+  DOCUMENT_ID_APP_SETTINGS,
 } from '../../../../constants';
 import { Tab } from '../tab/tab';
 import { NgrokTabContainer } from '../tab/ngrokTabContainer';
@@ -65,6 +66,7 @@ export interface TabBarProps {
   enablePresentationMode?: () => void;
   setActiveTab?: (documentId: string) => void;
   closeTab?: (documentId: string) => void;
+  setDirtyFlag?: (documentId: string, dirty: boolean) => void;
 }
 
 export interface TabBarState {
@@ -111,6 +113,16 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
           scrollable.scrollLeft = leftOffset;
         }
       }
+    }
+    // Set dirty flag to re-render the App Setttings component
+    if (
+      this.props.activeDocumentId != prevProps.activeDocumentId &&
+      this.props.activeDocumentId == DOCUMENT_ID_APP_SETTINGS
+    ) {
+      this.props.setDirtyFlag(
+        this.props.activeDocumentId,
+        this.props.documents[DOCUMENT_ID_APP_SETTINGS].dirty ? false : true
+      );
     }
   }
 

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBarContainer.ts
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBarContainer.ts
@@ -41,6 +41,7 @@ import {
   setActiveTab,
   splitTab,
   SharedConstants,
+  setDirtyFlag,
 } from '@bfemulator/app-shared';
 
 import { getTabGroupForDocument } from '../../../../state/helpers/editorHelpers';
@@ -76,6 +77,7 @@ const mapDispatchToProps = (dispatch): TabBarProps => ({
     dispatch(close(getTabGroupForDocument(documentId), documentId));
     dispatch(closeConversation(documentId));
   },
+  setDirtyFlag: (documentId: string, dirty: boolean) => dispatch(setDirtyFlag(documentId, dirty)),
 });
 
 export const TabBarContainer = connect(mapStateToProps, mapDispatchToProps)(TabBar);


### PR DESCRIPTION
Fixes MS63968

### Description

As reported by the issue, the focus was not properly set after opening the Emulator Settings and changing to another tab, and go back to the Emulator Settings tab.

### Changes made

- Updated the appSettingsEditor component to include the componentDidUpdate method for setting the focus on the first element
- Updated the tabBar component to call the setDirtyFlag action so the settings editor can handle the focus

### Testing

There was no need to update unit tests.

appSettingsEditor tests
![imagen](https://user-images.githubusercontent.com/62261539/135510209-9d5a1cee-d5f7-4ea5-83a7-c292a30b369d.png)

tabBar Tests
![imagen](https://user-images.githubusercontent.com/62261539/135510164-f0f33dd4-5ae4-4ec5-b1e3-9b40959eedf4.png)
