### PR TITLE
Fix null name on focusable elements in main screen

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
@@ -88,6 +88,7 @@ export class ActivityWrapper extends Component<ActivityWrapperProps> {
         onKeyDown={this.onKeyDown}
         role="checkbox"
         tabIndex={0}
+        title={'activity'}
       >
         {children}
         {restartConversationBubble}

--- a/packages/extensions/json/bf-extension.json
+++ b/packages/extensions/json/bf-extension.json
@@ -52,7 +52,8 @@
                 "title":"Previous"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Previous"
               }
             }
           },
@@ -71,7 +72,8 @@
                 "title":"Next"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Next"
               }
             }
           },
@@ -90,7 +92,8 @@
                 "aria-label": "Hide diff"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Disabled diff"
               }
             }
           },


### PR DESCRIPTION
Fixes MS63991

### Description
As reported by the issue, the error 'The Name property of a focusable element must not be null' is reported in several components at the main chat screen.

### Changes made
Added name properties to the aforementioned elements.

### Testing
There were no need to update unit tests.