### PR TITLE
Fix elements disposition when the page is zoomed to 400%

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -1,5 +1,5 @@
 .right-column {
-  margin-left: 48px
+  padding-left: 48px
 }
 
 .version-number {
@@ -186,4 +186,24 @@
   > span {
     line-height: 3;
   }
+}
+
+.flex-row {
+  width: 100%;
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.flex-column {
+  flex: 0 1 100%;
+}
+
+@media all and (min-width: 1280px) {
+  .flex-column {
+    flex: 0 1 50%;
+  }
+}
+
+::-webkit-scrollbar-thumb {
+  background: #ccc !important;
 }

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
@@ -43,6 +43,7 @@ import * as styles from './welcomePage.scss';
 
 export interface WelcomePageProps {
   accessToken?: string;
+
   onNewBotClick?: () => void;
   showOpenBotDialog: () => void;
   sendNotification?: (error: Error) => void;
@@ -68,8 +69,8 @@ export class WelcomePage extends React.Component<WelcomePageProps, Record<string
 
     return (
       <GenericDocument>
-        <Row>
-          <Column className={styles.spacing}>
+        <Row className={styles.flexRow}>
+          <Column className={[styles.flexColumn, styles.spacing].join(' ')}>
             {headerSection}
             {startSection}
             <React.Fragment>
@@ -77,7 +78,7 @@ export class WelcomePage extends React.Component<WelcomePageProps, Record<string
               {signInSection}
             </React.Fragment>
           </Column>
-          <Column className={styles.rightColumn}>
+          <Column className={[styles.flexColumn, styles.rightColumn].join(' ')}>
             <HowToBuildABotContainer />
           </Column>
         </Row>

--- a/packages/app/client/src/ui/styles/globals.scss
+++ b/packages/app/client/src/ui/styles/globals.scss
@@ -101,4 +101,10 @@
   ::-webkit-scrollbar-thumb {
     background: transparent;
   }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
 }


### PR DESCRIPTION
Fixes MS63944

### Description

As reported by the issue, when the page was zoomed to 400%, the controls were not visible and could not be navigated properly.

### Changes made

- Added CSS styles to show a vertical scrollbar and adjust the elements disposition in a single column to avoid scrolling horizontally.

### Testing

No zoom applied
![imagen](https://user-images.githubusercontent.com/62261539/136035834-bf8ff1da-8f0f-4606-b7f2-a1fbef75f46b.png)

Zoom 400% applied
![imagen](https://user-images.githubusercontent.com/62261539/136035850-6e2a8f7f-3423-4e48-aaa1-11f35fdde97b.png)

No tests cases updated
![imagen](https://user-images.githubusercontent.com/62261539/136035945-60706c71-0991-44ba-83ec-433ac757544a.png)
