### PR TITLE
 Fix screen reader announcement in the recent bot list in the Welcome Page

### DIFF
--- a/packages/app/client/src/ui/editor/recentBotsList/recentBotsList.tsx
+++ b/packages/app/client/src/ui/editor/recentBotsList/recentBotsList.tsx
@@ -50,7 +50,7 @@ export class RecentBotsList extends Component<RecentBotsListProps, Record<string
     return (
       <div className={styles.section}>
         <SmallHeader className={styles.marginFix}>My Bots</SmallHeader>
-        <ul className={`${styles.recentBotsList} ${styles.well}`}>
+        <ul className={`${styles.recentBotsList} ${styles.well}`} role="presentation">
           {this.props.recentBots && this.props.recentBots.length ? (
             this.props.recentBots.slice(0, 10).map(
               (bot, index) =>


### PR DESCRIPTION
Fixes MS63767

### Description

As reported by the issue, when focus moves on the first item in the recent bot list, the screen reader announces "list 1".

### Changes made

- Added presentation role 

### Testing

No changes required