### PR TITLE
fix: [Chat with BOT] Focus indicator is not visible properly on Upload, Chat edit field, and Send control under chat section

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
@@ -123,6 +123,30 @@
   box-sizing: border-box;
 }
 
+button[class^="webchat--css"] {
+  &:focus {
+    outline: 1px solid var(--dialog-link-focus-color) !important;
+    margin: 2px;
+    outline-offset: 1px !important;
+
+    &::after {
+      border: var(--p-button-border-focus) !important;
+    }
+  }
+}
+
+input[class^="webchat__send"] {
+  &:focus {
+    outline: 1px solid var(--dialog-link-focus-color) !important;
+    margin: 2px;
+    outline-offset: 1px !important;
+
+    &::after {
+      border: var(--p-button-border-focus) !important;
+    }
+  }
+}
+
 button.bot-state-object {
   cursor: pointer;
   margin: 5px 16px;


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘Focus indicator is not visible properly on Upload, Chat edit field, and Send control under chat section’ was present in the Live chat screen.

### Changes made
We added two focus indicator styles inside the chat.scss class, defined by taking the className attributes.

### Testing
No unit tests needed to be modified for this change