### PR TITLE
fix: [New Bot Configuration Dialog] Screen Reader List announce with Hide Control under New Bot Configuration Dialog

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -196,7 +196,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
               type={revealSecret ? 'text' : 'password'}
             />
             &nbsp;
-            <ul className={dialogStyles.actionsList}>
+            <ul className={dialogStyles.actionsList} role="region">
               <li>
                 <LinkButton
                   ariaLabel={revealSecret ? 'Hide secret' : 'Show secret'}


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘Screen Reader List announce with Hide Control under New Bot Configuration Dialog’ was present in the New bot configuration screen.

### Changes made
We added the region role.

### Testing
No unit tests needed to be modified for this change