### PR TITLE
fix: [New Bot Configuration Dialog] Screen Reader announcing invalid with required edit field, under New Bot Configuration Dialog

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -124,7 +124,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
             data-prop="name"
             onChange={this.onInputChange}
             label={'Bot name'}
-            required={true}
+            aria-required={true}
             name={'create-bot-name'}
           />
           <TextField
@@ -132,7 +132,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
             data-prop="endpoint"
             placeholder={endpointPlaceholder}
             label={'Endpoint URL'}
-            required={true}
+            aria-required={true}
             value={this.state.endpoint.endpoint}
             name={'create-bot-url'}
           />


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘Screen Reader announcing invalid with required edit field, under New Bot Configuration Dialog’ was present in the New bot configuration screen.

### Changes made
We replaced the required property with aria-required.

### Testing
No unit tests needed to be modified for this change