### PR TITLE
Fix element focus when opening the Ngrok Status Viewer tab

### DIFF
--- a/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
+++ b/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Column, Row, LinkButton, SmallHeader } from '@bfemulator/ui-react';
 import { TunnelCheckTimeInterval, TunnelError, TunnelStatus } from '@bfemulator/app-shared';
 
@@ -127,6 +127,17 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
     </section>
   );
 
+  let pingTunnelInputRef: HTMLButtonElement;
+  const setPingTunnelInputRef = (ref: HTMLButtonElement): void => {
+    pingTunnelInputRef = ref;
+  };
+
+  useEffect(() => {
+    if (pingTunnelInputRef) {
+      pingTunnelInputRef.focus();
+    }
+  });
+
   return (
     <GenericDocument className={styles.ngrokDebuggerContainer}>
       <h1>
@@ -147,7 +158,7 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
                 </span>
               </div>
               <div>
-                <LinkButton linkRole={true} onClick={props.onPingTunnelClick}>
+                <LinkButton linkRole={true} onClick={props.onPingTunnelClick} buttonRef={setPingTunnelInputRef}>
                   Click here
                 </LinkButton>
                 &nbsp;to ping the tunnel now


### PR DESCRIPTION
Fixes MS63887

### Description

As reported by the issue, when the Ngrok Status Viewer tab is open, the focus should land on the first interactive control instead of being hidden.

### Changes made

- Added an input ref variable to set the focus to the "Click here" link button

### Testing

No changes required

![imagen](https://user-images.githubusercontent.com/62261539/141177961-86555b80-050f-4d52-a6a7-834e5643f13b.png)
