### PR TITLE
Fix: [Chat with BOT] After Opening Chat with Bot screen, focus indicator does not land on Live Chat Tab control

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -92,8 +92,6 @@ export interface EmulatorProps {
 }
 
 export class Emulator extends React.Component<EmulatorProps, Record<string, unknown>> {
-  private restartButtonRef: HTMLButtonElement;
-
   private readonly onVerticalSizeChange = debounce((sizes: SplitterSize[]) => {
     this.props.ui = {
       ...this.props.ui,
@@ -107,12 +105,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
       horizontalSplitter: sizes,
     };
   }, 500);
-
-  componentDidMount() {
-    if (this.restartButtonRef) {
-      this.restartButtonRef.focus();
-    }
-  }
 
   componentWillMount() {
     window.addEventListener('keydown', this.keyboardEventListener);
@@ -159,7 +151,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
             options={[NewUserId, SameUserId]}
             onClick={this.onRestartOptionSelected}
             onDefaultButtonClick={this.onStartOverClick}
-            buttonRef={this.setRestartButtonRef}
             submenuLabel={isMac() ? 'Restart conversation sub menu' : ''}
           />
           <button
@@ -307,10 +298,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
   private onReconnectToDebugBotClick = () => {
     const { documentId } = this.props;
     this.props.restartConversation(documentId, true, false);
-  };
-
-  private setRestartButtonRef = (ref: HTMLButtonElement): void => {
-    this.restartButtonRef = ref;
   };
 
   private readonly keyboardEventListener: EventListener = (event: KeyboardEvent): void => {

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -57,6 +57,7 @@ export interface TabState {
 }
 
 export class Tab extends React.Component<TabProps, TabState> {
+  private tabRef: HTMLButtonElement;
   constructor(props: TabProps) {
     super(props);
 
@@ -64,6 +65,12 @@ export class Tab extends React.Component<TabProps, TabState> {
       draggedOver: false,
       owningEditor: getTabGroupForDocument(props.documentId),
     };
+  }
+
+  componentDidMount() {
+    if (this.tabRef) {
+      this.tabRef.focus();
+    }
   }
 
   public render() {
@@ -89,7 +96,14 @@ export class Tab extends React.Component<TabProps, TabState> {
         <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
         {this.props.dirty ? <span role="presentation">*</span> : null}
         <div className={styles.tabSeparator} role="presentation" />
-        <div className={styles.tabFocusTarget} role="tab" tabIndex={0} aria-label={`${label}`} aria-selected={active}>
+        <div
+          className={styles.tabFocusTarget}
+          role="tab"
+          tabIndex={0}
+          aria-label={`${label}`}
+          aria-selected={active}
+          ref={this.setTabRef}
+        >
           &nbsp;
         </div>
         <button
@@ -171,4 +185,8 @@ export class Tab extends React.Component<TabProps, TabState> {
         return styles.livechat;
     }
   }
+
+  private setTabRef = (ref: HTMLButtonElement): void => {
+    this.tabRef = ref;
+  };
 }

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -75,7 +75,6 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
   private readonly childRefs: HTMLElement[] = [];
   private _scrollable: HTMLElement;
   private activeIndex: number;
-  private liveChatRef: HTMLElement;
 
   constructor(props: TabBarProps) {
     super(props);
@@ -90,9 +89,6 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
 
   public componentDidMount() {
     window.addEventListener('keydown', this.onKeyDown);
-    /*if (this.liveChatRef) {
-      this.liveChatRef.focus();
-    }*/
   }
 
   public componentWillUnmount() {
@@ -303,7 +299,4 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
         return '';
     }
   }
-  private setLiveChatRef = (ref: HTMLElement): void => {
-    this.liveChatRef = ref;
-  };
 }

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -75,6 +75,7 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
   private readonly childRefs: HTMLElement[] = [];
   private _scrollable: HTMLElement;
   private activeIndex: number;
+  private liveChatRef: HTMLElement;
 
   constructor(props: TabBarProps) {
     super(props);
@@ -89,6 +90,9 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
 
   public componentDidMount() {
     window.addEventListener('keydown', this.onKeyDown);
+    /*if (this.liveChatRef) {
+      this.liveChatRef.focus();
+    }*/
   }
 
   public componentWillUnmount() {
@@ -299,4 +303,7 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
         return '';
     }
   }
+  private setLiveChatRef = (ref: HTMLElement): void => {
+    this.liveChatRef = ref;
+  };
 }

--- a/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
+++ b/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
@@ -67,7 +67,7 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
   }
 
   componentDidMount() {
-    this.onClickOption(0);
+    this.onClickOption(0, false);
   }
 
   public render(): JSX.Element {
@@ -158,18 +158,20 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
     }
   };
 
-  private onClickOption = (index: number): void => {
+  private onClickOption = (index: number, focus: boolean = true): void => {
     const { onClick, options = [] } = this.props;
     if (onClick && options.length > 0) {
       const newValue = options[index] || null;
       this.setState({ selected: index });
       onClick(newValue);
     }
-    this.hidePanel();
+    this.hidePanel(focus);
   };
 
-  private hidePanel = (): void => {
-    this.caretRef.focus();
+  private hidePanel = (focus: boolean = true): void => {
+    if (focus) {
+      this.caretRef.focus();
+    }
     this.setState({ expanded: false });
   };
 


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘After Opening Chat with Bot screen, focus indicator does not land on Live Chat Tab control’ was present in the Live Chat screen.

### Changes made
We removed the focus from the Restart conversation button, and created a ref to focus the Live Chat tab.

### Testing
No unit tests needed to be modified for this change