### PR TITLE
Fix: [SON] After selection of Copy JSON, it get copied but visually message not appear on screen as a Copied

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -89,6 +89,7 @@ export interface InspectorProps {
   trackEvent?: (name: string, properties?: { [key: string]: any }) => void;
   setHighlightedObjects?: (documentId: string, objects: Activity[]) => void;
   setInspectorObjects?: (documentId: string, inspectorObjects: Activity[]) => void;
+  showMessage?: (title: string, message: string) => void;
 }
 
 interface InspectorState {
@@ -398,6 +399,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
 
     if (id == 'copyJson') {
       this.props.createAriaAlert('Activity JSON copied to clipboard.');
+      this.props.showMessage('Copy to clipboard', 'JSON copied.');
       return clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
     }
 

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
@@ -67,6 +67,13 @@ const mapDispatchToProps = dispatch => {
       dispatch(setHighlightedObjects(documentId, objects)),
     setInspectorObjects: (documentId: string, inspectorObjects: Activity[]) =>
       dispatch(setInspectorObjects(documentId, inspectorObjects)),
+    showMessage: (title: string, message: string) =>
+      dispatch(
+        executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+          message: message,
+          title: title,
+        })
+      ),
   };
 };
 


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘After selection of Copy JSON, it get copied but visually message not appear on screen as a Copied’ was present in the JSON screen.

### Changes made
We added a message announcing that JSON has been copied successfully.

### Testing
No unit tests needed to be modified for this change