### PR TITLE
Enable screen reader to announce when the panel is collapsed or expanded

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
@@ -62,3 +62,9 @@
     height: 100%;
   }
 }
+
+.aria-live-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss.d.ts
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss.d.ts
@@ -4,3 +4,4 @@ export const expanded: string;
 export const header: string;
 export const accessories: string;
 export const body: string;
+export const ariaLiveRegion: string;

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -80,6 +80,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           <div className={styles.accessories}>
             {filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseControls))}
           </div>
+          {this.announcePanelState}
         </div>
         <div className={styles.body}>
           {expanded && filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseContent))}
@@ -119,4 +120,14 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
       this.onToggleExpandedButtonClick();
     }
   };
+
+  private get announcePanelState(): React.ReactNode {
+    const { expanded } = this.state;
+    const { title } = this.props;
+    return (
+      <span id="panelstate" aria-live={'polite'} className={styles.ariaLiveRegion}>
+        {expanded ? `${title} panel expanded` : `${title} panel collapsed`}
+      </span>
+    );
+  }
 }


### PR DESCRIPTION
Fixes MS63912

### Description

As reported by the issue, when the side panels are expanded or collapsed, the screen reader state information is not announced and it would be confusing for users to know if the action was completed or not.

### Changes made

- Added a span with an aria-live region, to enable the screen reader to detect when the panel is collapsed or expanded

### Testing

No changes required
resourceExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142018681-487b9236-8b4b-4f50-9654-65a4de572357.png)

endpointExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142018722-f6a5210e-b7b4-416d-8a86-f69c8e2aec94.png)

servicesExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142019058-efcc2a87-011a-43e8-be39-88881a4220a7.png)
