### PR TITLE
Fix: [Resources] After selection of Resources control focus does not land on first interactive control under Resources pane

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
@@ -47,6 +47,14 @@ export interface ResourcesBarProps {
 }
 
 export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps> {
+  private chatFilesRef: HTMLElement;
+
+  public componentDidMount(): void {
+    if (this.chatFilesRef) {
+      this.chatFilesRef.focus();
+    }
+  }
+
   public render() {
     return (
       <div className={styles.resourcesBar}>
@@ -56,6 +64,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
         <ul className={explorerStyles.explorerSet}>
           <li>
             <ResourceExplorerContainer
+              elementRef={this.setChatFilesRef}
               files={this.props.chatFiles}
               resourcesPath={this.props.chatsPath}
               title="chat files"
@@ -72,4 +81,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
       </div>
     );
   }
+  private setChatFilesRef = (elementRef: HTMLElement) => {
+    this.chatFilesRef = elementRef;
+  };
 }

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -45,6 +45,7 @@ export interface ServicePaneProps extends ServicePaneState {
   title?: string;
   ariaLabel?: string;
   sortCriteria?: string;
+  elementRef?: (ref: HTMLElement) => void;
 }
 
 export interface ServicePaneState {
@@ -181,6 +182,7 @@ export abstract class ServicePane<
         className={styles.servicePane}
         key={this.props.title}
         title={this.props.title}
+        elementRef={this.props.elementRef}
         ariaLabel={this.props.ariaLabel}
         expanded={this.state.expanded}
       >

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -43,6 +43,7 @@ export interface ExpandCollapseProps {
   title?: string;
   className?: string;
   ariaLabel?: string;
+  elementRef?: (ref: HTMLElement) => void;
 }
 
 export interface ExpandCollapseState {
@@ -66,6 +67,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
     return (
       <div className={`${styles.expandCollapse} ${className} ${expanded ? 'expanded' : ''}`}>
         <div
+          ref={this.setElementRef}
           aria-expanded={expanded}
           aria-label={ariaLabel}
           role="toolbar"
@@ -117,6 +119,12 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
   private onHeaderKeyPress = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === ' ') {
       this.onToggleExpandedButtonClick();
+    }
+  };
+  private setElementRef = (ref: HTMLElement): void => {
+    const { elementRef } = this.props;
+    if (elementRef) {
+      elementRef(ref);
     }
   };
 }


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘After selection of Resources control focus does not land on first interactive control under Resources pane’ was present in the resources pane screen.

### Changes made
We added a ref to focus the first element inside the resources pane.

### Testing
No unit tests needed to be modified for this change