### PR TITLE
Fix: [Bot Explorer] Screen reader descriptive information does not announce for Add control under present Bot Explorer

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -89,7 +89,7 @@ export abstract class ServicePane<
           </svg>
         </button>
         <button
-          aria-label="Add"
+          aria-label={'Add ' + this.props.title}
           onKeyPress={this.onControlKeyPress}
           onClick={this.onAddIconClick}
           className={`${styles.addIconButton} ${styles.serviceIcon}`}


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘Screen reader descriptive information does not announce for Add control under present Bot Explorer’ was present in the Bot Explorer screen.

### Changes made
We modified the add button aria-label to announce the title of each button.

### Testing
No unit tests needed to be modified for this change