### PR TITLE
Removed the disabled attribute to make it visible and accessible thro…

### DIFF
--- a/packages/extensions/json/bf-extension.json
+++ b/packages/extensions/json/bf-extension.json
@@ -90,10 +90,6 @@
                 "aria-selected": true,
                 "title": "Hide diff",
                 "aria-label": "Hide diff"
-              },
-              "disabled": {
-                "aria-disabled": true,
-                "title":"Disabled diff"
               }
             }
           },


### PR DESCRIPTION
Fixes MS64006

### Description

As reported by the issue, the Diff button can be accessed using the mouse but not the keyboard.

### Changes made

- Removed the disabled attribute from the Diff button to make it visible and accessible through the keyboard

### Testing

No changes required
