### PR TITLE
Fix: [Toggle Full screen] After Toggle full screen and exit full screen, Screen reader announce same information

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -36,6 +36,8 @@ import { MenuItem } from '@bfemulator/ui-react';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { remote } from 'electron';
 
+import { ariaAlertService } from '../../a11y';
+
 const {
   Channels: { HelpLabel, ReadmeUrl },
   Commands: {
@@ -181,6 +183,11 @@ export class AppMenuTemplate {
         onClick: () => {
           const currentWindow = remote.getCurrentWindow();
           currentWindow.setFullScreen(!currentWindow.isFullScreen());
+          if (currentWindow.isFullScreen()) {
+            ariaAlertService.alert('Entering full screen');
+          } else {
+            ariaAlertService.alert('Exiting full screen');
+          }
         },
         subtext: 'F11',
       },

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -33,6 +33,7 @@
 import { isLinux, isMac, Notification, NotificationType, SharedConstants } from '@bfemulator/app-shared';
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
+import { ariaAlertService } from '../ui/a11y';
 
 const maxZoomFactor = 3; // 300%
 const minZoomFactor = 0.25; // 25%;
@@ -114,6 +115,11 @@ class EventHandlers {
     if (key === 'f11') {
       const currentWindow = remote.getCurrentWindow();
       currentWindow.setFullScreen(!currentWindow.isFullScreen());
+      if (currentWindow.isFullScreen()) {
+        ariaAlertService.alert('Entering full screen');
+      } else {
+        ariaAlertService.alert('Exiting full screen');
+      }
     }
     // Ctrl+Shift+I
     if (ctrlOrCmdPressed && shiftPressed && key === 'i') {


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘After Toggle full screen and exit full screen, Screen reader announce same information’ was present in the View screen.

### Changes made
We added two audio alerts for entering and exiting fullscreen.

### Testing
No unit tests needed to be modified for this change