### PR TITLE
Fix: [Bot Explorer] Luminosity ratio is less than for added endpoint http://local... text, under Bot Explorer

### DIFF
--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -6,7 +6,7 @@ html {
   --box-shadow-color: var(--neutral-6);
 
   /* Highlight colors */
-  --list-item-color: var(--neutral-9);
+  --list-item-color: var(--neutral-16);
   --list-item-selected-color: var(--neutral-2);
   --list-item-hover-bg: var(--neutral-4);
   --list-item-hover-border: 1px dashed transparent;


### PR DESCRIPTION
### Description
As reported by the issue "Luminosity ratio is less than for added endpoint http://local... text, under Bot Explorer" was present under bot explorer screen

### Changes made
We changed the colour on the service pane list items.

### Testing
No unit tests needed to be modified for this change