### PR TITLE
Added a tooltip for keyboard navigation

### DIFF
--- a/packages/app/client/src/ui/shell/navBar/navBar.scss
+++ b/packages/app/client/src/ui/shell/navBar/navBar.scss
@@ -3,7 +3,6 @@
   box-shadow: var(--box-shadow-right);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   position: relative;
   width: 50px;
 }
@@ -125,6 +124,10 @@
     border: 1px solid transparent;
   }
 
+  > span {
+    visibility: visible;
+  }
+
   &:hover {
     border: var(--nav-link-hover-border);
     > div {
@@ -139,6 +142,23 @@
     }
     &::before {
       opacity: var(--nav-focused-tag-bg-opacity);
+    }
+
+    > span {
+      position: absolute;
+      z-index: 1;
+      background-color: #fff;
+      color: #000;
+      border: 1px solid #000;
+      white-space: nowrap;
+      font-size: 12px;
+      text-align: center;
+      padding: 4px;
+      top: 22px;
+      left: 22px;
+      transition-property: visibility;
+      transition-duration: 2s;
+      visibility: hidden;
     }
   }
 

--- a/packages/app/client/src/ui/shell/navBar/navBar.tsx
+++ b/packages/app/client/src/ui/shell/navBar/navBar.tsx
@@ -127,6 +127,7 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
         >
           <div />
           {this.renderNotificationBadge(title)}
+          {this.renderKeyboardTooltip(title)}
         </button>
       );
     });
@@ -144,5 +145,10 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
       return numUnreadNotifications ? <span className={styles.badge}>{numUnreadNotifications}</span> : null;
     }
     return null;
+  }
+
+  /** Renders a tooltip for keyboard navigation */
+  private renderKeyboardTooltip(title: string): JSX.Element {
+    return <span>{title}</span>;
   }
 }


### PR DESCRIPTION
Fixes MS63911

### Description

As reported by the issue, when the user navigates through the menu icons using the keyboard, there is no tooltip or visual message that describes the icon's purpose.

### Changes made

- Added a span element to be shown as a tooltip for each icon on the left panel

### Testing

No changes required

![imagen](https://user-images.githubusercontent.com/62261539/143447532-99b89ec6-1422-419a-8105-4e12fbaf53eb.png)
