### PR TITLE
Fix the active theme after enabling the High Contrast option in Ubuntu OS

### DIFF
--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -293,7 +293,7 @@ class EmulatorApplication {
     const { theme, availableThemes } = getSettings().windowState;
     const themeInfo = availableThemes.find(availableTheme => availableTheme.name === theme);
 
-    const isHighContrast = nativeTheme.shouldUseInvertedColorScheme;
+    const isHighContrast = nativeTheme.shouldUseInvertedColorScheme || nativeTheme.shouldUseHighContrastColors;
 
     const themeName = isHighContrast ? 'high-contrast' : themeInfo.name;
     const themeComponents = isHighContrast ? path.join('.', 'themes', 'high-contrast.css') : themeInfo.href;


### PR DESCRIPTION
Fixes MS64460

### Description

As reported by the issue, when activating the High Contrast feature in Ubuntu, the emulator app does not change the theme as expected.

### Changes made

- Added the `shouldUseHighContrastColors` property to change the theme accordingly

### Testing

No changes required

![imagen](https://user-images.githubusercontent.com/62261539/143487679-628c2694-9810-40ca-879b-b6d7f40b66fb.png)
