### PR TITLE
fix: [Screen Reader- Bot Framework Emulator- Open a bot] Screen reader does not announce error message information on Bot URL edit field under Open a bot

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -147,14 +147,11 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
 
   private get errorMessage(): ReactNode {
     const { errorMessage } = this.props;
-    if (errorMessage) {
-      return (
-        <sub id={this.errorMessageId} className={styles.errorMessage}>
-          {errorMessage}
-        </sub>
-      );
-    }
-    return undefined;
+    return (
+      <sub id={this.errorMessageId} className={styles.errorMessage} aria-live={'polite'}>
+        {errorMessage ? errorMessage : null}
+      </sub>
+    );
   }
 
   private get errorMessageId(): string {


### PR DESCRIPTION
### Description
As reported by the issue "Screen reader does not announce error message information on Bot URL edit field under Open a bot" was present under open bot dialog screen

### Changes made
We added an aria-live attribute and also removed the if statement under the errorMessage() method in autoComplete class.

### Testing
No unit tests needed to be modified for this change