### PR TITLE
Added a regex validation instead of using the number type input

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -134,8 +134,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
       mode,
       isDebug,
       isAzureGov,
-      randomSeed,
-      randomValue,
+      randomSeed = '',
+      randomValue = '',
       speechKey,
       speechRegion,
     } = this.state;
@@ -204,23 +204,17 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               inputContainerClassName={openBotStyles.inputContainerRow}
               name="randomSeed"
               label="Test Options - Random Seed"
-              onChange={this.onInputChange}
+              onChange={this.onNumericInputChange}
               placeholder="Optional"
-              type="number"
               value={randomSeed}
-              min="0"
-              max="9999"
             />
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
               label="Test Options - Random Value"
               name="randomValue"
-              onChange={this.onInputChange}
+              onChange={this.onNumericInputChange}
               placeholder="Optional"
-              type="number"
               value={randomValue}
-              min="0"
-              max="9999"
             />
           </Row>
           <Row className={openBotStyles.rowOverride}>
@@ -263,6 +257,14 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const { type, files, value, name } = event.target;
     const newValue = type === 'file' ? files.item(0).path : value;
     this.setState({ [name]: newValue });
+  };
+
+  private onNumericInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value, name } = event.target;
+    const numberRegEx = /^[0-9\b]+$/;
+    if (value === '' || numberRegEx.test(value)) {
+      this.setState({ [name]: value });
+    }
   };
 
   private onChannelServiceCheckboxClick = (event: MouseEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fixes MS64463 and MS64466

### Description

As reported by the issue, when focusing on the fields "Test Options - Random Seed" and Test Options - Random Value" the screen reader is reading the label twice.

### Changes made

- Removed `type="number"` as it was making the screen reader announces the label twice
- Added a regex expression to validate the input value for both numeric fields

### Testing

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/143904561-2a2e227a-de05-46e9-b109-2e5d6f3aba21.png)
