### PR TITLE
fix: [Activity Update section] After applying large text, Activity Update section content information does not visible properly

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/log/log.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/log/log.scss
@@ -10,6 +10,7 @@
     padding: 0 16px;
     font-family: var(--monospace-font-family);
     cursor: pointer;
+    word-wrap: break-word;
 
     &:hover {
       background-color: var(--log-panel-entry-hover-bg);


### PR DESCRIPTION
### Description
As reported by the issue "after applying large text, content information does not visible properly" was present under Activity Update screen

### Changes made
We added a word-wrap attribute and set it with "break-word" in log.scss class.

### Testing
No unit tests needed to be modified for this change