### PR TITLE
Added selected tab announcement for Linux OS

### DIFF
--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss
@@ -126,3 +126,9 @@
   right: 0;
   background-color: var(--tab-separator-bg);
 }
+
+.aria-live-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
@@ -10,3 +10,4 @@ export const draggedOverEditorTab: string;
 export const activeEditorTab: string;
 export const tabFocusTarget: string;
 export const tabSeparator: string;
+export const ariaLiveRegion: string;

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -81,43 +81,45 @@ export class Tab extends React.Component<TabProps, TabState> {
     const iconClass = this.iconClass;
 
     return (
-      <div
-        className={`${styles.tab} ${activeClassName} ${draggedOverClassName}`}
-        draggable={true}
-        onDragOver={this.onDragOver}
-        onDragEnter={this.onDragEnter}
-        onDragStart={this.onDragStart}
-        onDrop={this.onDrop}
-        onDragLeave={this.onDragLeave}
-        onDragEnd={this.onDragEnd}
-        role="presentation"
-      >
-        {isLinux() ? this.announceTabState : null}
-        {this.props.children}
-        {!this.props.hideIcon && <span className={`${styles.editorTabIcon} ${iconClass}`} role="presentation" />}
-        <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
-        {this.props.dirty ? <span role="presentation">*</span> : null}
-        <div className={styles.tabSeparator} role="presentation" />
+      <>
         <div
-          className={styles.tabFocusTarget}
-          role="tab"
-          tabIndex={0}
-          aria-label={`${label}`}
-          aria-selected={active}
-          ref={this.setTabRef}
+          className={`${styles.tab} ${activeClassName} ${draggedOverClassName}`}
+          draggable={true}
+          onDragOver={this.onDragOver}
+          onDragEnter={this.onDragEnter}
+          onDragStart={this.onDragStart}
+          onDrop={this.onDrop}
+          onDragLeave={this.onDragLeave}
+          onDragEnd={this.onDragEnd}
+          role="presentation"
         >
-          &nbsp;
+          {this.props.children}
+          {!this.props.hideIcon && <span className={`${styles.editorTabIcon} ${iconClass}`} role="presentation" />}
+          <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
+          {this.props.dirty ? <span role="presentation">*</span> : null}
+          <div className={styles.tabSeparator} role="presentation" />
+          <div
+            className={styles.tabFocusTarget}
+            role="tab"
+            tabIndex={0}
+            aria-label={`${label}`}
+            aria-selected={active}
+            ref={this.setTabRef}
+          >
+            &nbsp;
+          </div>
+          <button
+            type="button"
+            title={`Close ${label} tab`}
+            className={styles.editorTabClose}
+            onKeyPress={this.onCloseButtonKeyPress}
+            onClick={this.onCloseClick}
+          >
+            <span />
+          </button>
         </div>
-        <button
-          type="button"
-          title={`Close ${label} tab`}
-          className={styles.editorTabClose}
-          onKeyPress={this.onCloseButtonKeyPress}
-          onClick={this.onCloseClick}
-        >
-          <span />
-        </button>
-      </div>
+        {isLinux() ? this.announceTabState : null}
+      </>
     );
   }
 

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -34,6 +34,7 @@
 import { TruncateText } from '@bfemulator/ui-react';
 import * as React from 'react';
 import { DragEvent, KeyboardEvent, SyntheticEvent } from 'react';
+import { isLinux } from '@bfemulator/app-shared';
 
 import { getTabGroupForDocument } from '../../../../state/helpers/editorHelpers';
 import { DOCUMENT_ID_APP_SETTINGS, DOCUMENT_ID_MARKDOWN_PAGE, DOCUMENT_ID_WELCOME_PAGE } from '../../../../constants';
@@ -115,6 +116,7 @@ export class Tab extends React.Component<TabProps, TabState> {
         >
           <span />
         </button>
+        {isLinux() ? this.announceTabState : null}
       </div>
     );
   }
@@ -189,4 +191,13 @@ export class Tab extends React.Component<TabProps, TabState> {
   private setTabRef = (ref: HTMLButtonElement): void => {
     this.tabRef = ref;
   };
+
+  private get announceTabState(): React.ReactNode {
+    const { active, label } = this.props;
+    return (
+      <span id="tabState" aria-live={'polite'}>
+        {active ? `${label} tab selected` : ''}
+      </span>
+    );
+  }
 }

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -92,6 +92,7 @@ export class Tab extends React.Component<TabProps, TabState> {
         onDragEnd={this.onDragEnd}
         role="presentation"
       >
+        {isLinux() ? this.announceTabState : null}
         {this.props.children}
         {!this.props.hideIcon && <span className={`${styles.editorTabIcon} ${iconClass}`} role="presentation" />}
         <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
@@ -116,7 +117,6 @@ export class Tab extends React.Component<TabProps, TabState> {
         >
           <span />
         </button>
-        {isLinux() ? this.announceTabState : null}
       </div>
     );
   }

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -195,7 +195,7 @@ export class Tab extends React.Component<TabProps, TabState> {
   private get announceTabState(): React.ReactNode {
     const { active, label } = this.props;
     return (
-      <span id="tabState" aria-live={'polite'}>
+      <span id="tabState" aria-live={'polite'} className={styles.ariaLiveRegion}>
         {active ? `${label} tab selected` : ''}
       </span>
     );


### PR DESCRIPTION
Fixes MS64523

### Description

As reported by the issue, when selecting a tab on the Emulator app in Linux OS, the screen reader does not announce that is selected.

### Changes made

- Added an aria-live element to announce the selected tab. This fix applies only to Linux OS.

### Testing

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/144487979-4758dd77-96dd-4dae-ad18-b571dfdc05e7.png)
