### PR TITLE
Added a visual message when using the toggle full screen menu option

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -36,8 +36,6 @@ import { MenuItem } from '@bfemulator/ui-react';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../../a11y';
-
 const {
   Channels: { HelpLabel, ReadmeUrl },
   Commands: {
@@ -184,9 +182,15 @@ export class AppMenuTemplate {
           const currentWindow = remote.getCurrentWindow();
           currentWindow.setFullScreen(!currentWindow.isFullScreen());
           if (currentWindow.isFullScreen()) {
-            ariaAlertService.alert('Entering full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Entering full screen.',
+              title: 'Toggle Full Screen option',
+            });
           } else {
-            ariaAlertService.alert('Exiting full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Exiting full screen.',
+              title: 'Toggle Full Screen option',
+            });
           }
         },
         subtext: 'F11',

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -34,7 +34,7 @@ import { isLinux, isMac, Notification, NotificationType, SharedConstants } from 
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../ui/a11y';
+const { Electron } = SharedConstants.Commands;
 
 const maxZoomFactor = 3; // 300%
 const minZoomFactor = 0.25; // 25%;
@@ -117,9 +117,15 @@ class EventHandlers {
       const currentWindow = remote.getCurrentWindow();
       currentWindow.setFullScreen(!currentWindow.isFullScreen());
       if (currentWindow.isFullScreen()) {
-        ariaAlertService.alert('Entering full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Entering full screen.',
+          title: 'Toggle Full Screen option',
+        });
       } else {
-        ariaAlertService.alert('Exiting full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Exiting full screen.',
+          title: 'Toggle Full Screen option',
+        });
       }
     }
     // Ctrl+Shift+I


### PR DESCRIPTION
Fixes MS64661

### Description

As reported by the issue, when toggling the full-screen mode on and off, the user does not get a visual message that informs that the action was completed successfully.

### Changes made

- Added a message box to show the full-screen state to the user

### Testing

Test cases executed successfully

eventHandlers tests cases
![imagen](https://user-images.githubusercontent.com/62261539/144897786-6b67d219-1e67-4b83-b313-75fb76013caf.png)

appMenuTemplate test cases
![imagen](https://user-images.githubusercontent.com/62261539/144897843-9a2eb7d5-8559-484a-bbdf-404a39a15574.png)
