### PR TITLE
Fix: [Resource] Screen reader announcing role as a toolbar for "Chat files and Transcripts" control under Resource section.

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -37,7 +37,6 @@ import { KeyboardEvent } from 'react';
 import { filterChildren, hmrSafeNameComparison } from '../../utils';
 
 import * as styles from './expandCollapse.scss';
-import { button } from '../../widget/button/button.scss';
 
 export interface ExpandCollapseProps {
   expanded?: boolean;

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -37,6 +37,7 @@ import { KeyboardEvent } from 'react';
 import { filterChildren, hmrSafeNameComparison } from '../../utils';
 
 import * as styles from './expandCollapse.scss';
+import { button } from '../../widget/button/button.scss';
 
 export interface ExpandCollapseProps {
   expanded?: boolean;
@@ -70,7 +71,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           ref={this.setElementRefHandler}
           aria-expanded={expanded}
           aria-label={ariaLabel}
-          role="toolbar"
+          role="button"
           tabIndex={0}
           onKeyPress={onHeaderKeyPress}
           className={styles.header}


### PR DESCRIPTION
### Description
As reported by the issue "Screen reader announcing role as a toolbar for "Chat files and Transcripts" control" was present under Resource section.

### Changes made
We changed the role from "toolbar" to "button".

### Testing
No unit tests needed to be modified for this change