### PR TITLE
Added a message box to inform the user when clicking the Copy key button

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -62,6 +62,7 @@ import * as styles from './botCreationDialog.scss';
 
 export interface BotCreationDialogProps {
   createAriaAlert: (msg: string) => void;
+  showMessage?: (title: string, message: string) => void;
 }
 
 export interface BotCreationDialogState {
@@ -297,10 +298,10 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
       return null;
     }
     if (copyTextToClipboard(this.secretInputRef.value)) {
-      ariaAlertService.alert('Secret copied to clipboard.');
+      this.props.showMessage('Copy', 'Secret copied to clipboard.');
     } else {
       const err = 'Failed to copy secret to clipboard.';
-      ariaAlertService.alert(err);
+      this.props.showMessage('Copy', err);
       // eslint-disable-next-line no-console
       console.error(err);
     }

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialogContainer.ts
@@ -32,6 +32,7 @@
 //
 
 import { connect } from 'react-redux';
+import { executeCommand, SharedConstants } from '@bfemulator/app-shared';
 
 import { ariaAlertService } from '../../a11y';
 
@@ -42,6 +43,13 @@ const mapDispatchToProps = (_dispatch): BotCreationDialogProps => {
     createAriaAlert: (msg: string) => {
       ariaAlertService.alert(msg);
     },
+    showMessage: (title: string, message: string) =>
+      _dispatch(
+        executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+          message: message,
+          title: title,
+        })
+      ),
   };
 };
 

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
@@ -54,6 +54,13 @@ const mapDispatchToProps = dispatch => ({
     dispatch(executeCommand(true, SharedConstants.Commands.Electron.OpenExternal, null, url));
   },
   sendNotification: notification => dispatch(beginAdd(notification)),
+  showMessage: (title: string, message: string) =>
+    dispatch(
+      executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+        message: message,
+        title: title,
+      })
+    ),
 });
 
 export const BotSettingsEditorContainer = connect(mapStateToProps, mapDispatchToProps)(BotSettingsEditor);

--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -36,8 +36,6 @@ import { MenuItem } from '@bfemulator/ui-react';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../../a11y';
-
 const {
   Channels: { HelpLabel, ReadmeUrl },
   Commands: {
@@ -184,9 +182,15 @@ export class AppMenuTemplate {
           const currentWindow = remote.getCurrentWindow();
           currentWindow.setFullScreen(!currentWindow.isFullScreen());
           if (currentWindow.isFullScreen()) {
-            ariaAlertService.alert('Entering full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Entering full screen.',
+              title: 'Toggle Full Screen option',
+            });
           } else {
-            ariaAlertService.alert('Exiting full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Exiting full screen.',
+              title: 'Toggle Full Screen option',
+            });
           }
         },
         subtext: 'F11',

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -34,7 +34,7 @@ import { isLinux, isMac, Notification, NotificationType, SharedConstants } from 
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../ui/a11y';
+const { Electron } = SharedConstants.Commands;
 
 const maxZoomFactor = 3; // 300%
 const minZoomFactor = 0.25; // 25%;
@@ -117,9 +117,15 @@ class EventHandlers {
       const currentWindow = remote.getCurrentWindow();
       currentWindow.setFullScreen(!currentWindow.isFullScreen());
       if (currentWindow.isFullScreen()) {
-        ariaAlertService.alert('Entering full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Entering full screen.',
+          title: 'Toggle Full Screen option',
+        });
       } else {
-        ariaAlertService.alert('Exiting full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Exiting full screen.',
+          title: 'Toggle Full Screen option',
+        });
       }
     }
     // Ctrl+Shift+I


### PR DESCRIPTION
Fixes MS64663

### Description

As reported by the issue, after clicking on the Copy button, there is no message displayed to inform the user that the action was executed.

### Changes made

- Added a message box to inform the user that the action was completed successfully (or not).

### Testing

Test cases executed successfully

openBotDialog test cases
![imagen](https://user-images.githubusercontent.com/62261539/145091044-7151dcbf-7ab5-42d5-9a18-e489eb3549d3.png)
