### PR TITLE
fix: [Resource] Screen reader is not announcing the information "you do not have any chat files in dialog" under Chat files.

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -84,7 +84,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           </div>
           {this.announcePanelState}
         </div>
-        <div className={styles.body}>
+        <div className={styles.body} aria-live={'polite'}>
           {expanded && filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseContent))}
         </div>
       </div>


### PR DESCRIPTION
Description
As reported by the issue "Screen reader is not announcing the information "you do not have any chat files in dialog" was present under Resource section.

Changes made
We added an aria-live set up as "polite".

Testing
No unit tests needed to be modified for this change