### PR TITLE
Fix: [JSON] Screen reader announcing role as a Button with JSON

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -269,6 +269,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
         key={config.id}
         disabled={!enabled}
         name={config.id}
+        role={config.id == 'json' ? 'tab' : null}
         data-current-state={state}
         onClick={this.accessoryClick}
         aria-hidden={button.state === 'disabled' ? true : false}


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘Screen reader announcing role as a Button with JSON’ was present in the inspector screen.

### Changes made
We added a tab role when validating the config.id being "json"

### Testing
![image](https://user-images.githubusercontent.com/64086728/145624415-abcbda1d-553c-46cd-ae26-9b90170bcbfa.png)
