### PR TITLE
Fix screen reader announcement for password entry on Linux

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { beginAdd, executeCommand, newNotification, SharedConstants } from '@bfemulator/app-shared';
+import { beginAdd, executeCommand, isLinux, newNotification, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl, uniqueId } from '@bfemulator/sdk-shared';
 import {
   Checkbox,
@@ -149,6 +149,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
             <TextField
               inputContainerClassName={dialogStyles.inputContainer}
               label="Microsoft App password"
+              ariaLabel={isLinux() ? 'Microsoft App' : null}
               data-prop="appPassword"
               onChange={this.onInputChange}
               placeholder="Optional"

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -45,6 +45,7 @@ import {
 import * as React from 'react';
 import { ChangeEvent, Component, MouseEvent, ReactNode } from 'react';
 import { EmulatorMode } from '@bfemulator/sdk-shared';
+import { isLinux } from '@bfemulator/app-shared';
 
 import * as dialogStyles from '../dialogStyles.scss';
 
@@ -171,6 +172,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
               label="Microsoft App password"
+              ariaLabel={isLinux() ? 'Microsoft App' : null}
               name="appPassword"
               onChange={this.onInputChange}
               placeholder="Optional"

--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -40,6 +40,7 @@ let id = 0;
 export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   required?: boolean;
   label?: string;
+  ariaLabel?: string;
   errorMessage?: string;
   inputContainerClassName?: string;
   inputRef?: (ref: HTMLInputElement) => void;
@@ -72,7 +73,13 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
       <div className={`${styles.inputContainer} ${inputContainerClassName}`}>
         {this.labelNode}
         <input
-          aria-label={errorMessage ? this.props.label + ', ' + errorMessage : undefined}
+          aria-label={
+            this.props.ariaLabel
+              ? this.props.ariaLabel
+              : errorMessage
+              ? this.props.label + ', ' + errorMessage
+              : undefined
+          }
           aria-required={required}
           className={inputClassName}
           id={this.inputId}
@@ -93,10 +100,14 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
   };
 
   protected get labelNode(): ReactNode {
-    const { label, required, disabled } = this.props;
+    const { label, required, disabled, ariaLabel } = this.props;
     const className = required ? styles.requiredIndicator : '';
     return label ? (
-      <label aria-disabled={disabled} htmlFor={this.inputId} className={`${className} ${styles.label}`}>
+      <label
+        aria-disabled={disabled}
+        htmlFor={ariaLabel ? null : this.inputId}
+        className={`${className} ${styles.label}`}
+      >
         {label}
       </label>
     ) : null;


### PR DESCRIPTION
Fixes MS64662 and MS64462

### Description

As reported by the issue, when focusing the field "Microsoft App Password" the screen reader is announcing the word "password" twice on Linux.

### Changes made

- Added an ariaLabel prop to adjust the screen reader announcement on Linux for this specific field

### Testing

Test cases executed successfully

botCreationDialog component
![imagen](https://user-images.githubusercontent.com/62261539/145832518-7ed06bca-b475-4f32-ab79-c1a1274899e2.png)

openBotDialog
![imagen](https://user-images.githubusercontent.com/62261539/145832689-75900d46-7154-4296-ac7c-57979e2b84b0.png)
