### PR TITLE
Fix: [Get Started with Channel (Bot Inspector)] After selection of Get Started with Channel (Bot Inspector) control focus does not land on first interactive control.

### DIFF
--- a/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
@@ -33,6 +33,7 @@
 import * as React from 'react';
 import { Component } from 'react';
 import MarkdownIt from 'markdown-it';
+import ReactHtmlParser from 'react-html-parser';
 
 import { GenericDocument } from '../../layout';
 
@@ -80,15 +81,23 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
   }
 
   public render() {
+    const hrefConst = '#bot-state-inspection';
+    const transform = node => {
+      console.log(node);
+      if (node.name == 'a' && node.attribs && node.attribs.href == hrefConst) {
+        return (
+          <a ref={this.setBotInspectorRef} href={hrefConst}>
+            jump to Bot State Inspection
+          </a>
+        );
+      }
+    };
     const children = !this.props.onLine ? (
       MarkdownPage.offlineElement
     ) : (
-      <div
-        className={styles.markdownContainer}
-        ref={this.setBotInspectorRef}
-        tabIndex={0}
-        dangerouslySetInnerHTML={{ __html: MarkdownPage.renderMarkdown(this.props.markdown) }}
-      />
+      <div className={styles.markdownContainer}>
+        {ReactHtmlParser(MarkdownPage.renderMarkdown(this.props.markdown), { transform })}
+      </div>
     );
     return <GenericDocument>{children}</GenericDocument>;
   }


### PR DESCRIPTION
### Description
As reported in the issue, the error ‘After selection of Get Started with Channel (Bot Inspector) control focus does not land on first interactive control’ was present in the Help screen.

### Changes made
We implemented the react-html-parser library to have the page rendered as an html instead of rendering it from a markdown, in this way, we were able to set a ref in order to focus the first interactive control.

### Testing
No unit tests needed to be modified for this change.